### PR TITLE
Refine the trade protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,22 +77,22 @@ be possible to cancel the trade and invalidate that signature if the
 trade has not gone through yet.  In XAYA, this is easily possible by
 simply double-spending one of the inputs for the original transaction.
 
-In this context, it seems beneficial to have the *seller* be the first party
-that signs a transaction.  Since they send a move as part of the trade,
-only the name input belongs to them.  This is a single, well-defined
-UTXO that can be double spent to invalidate the transaction.  This can be
-done easily through a simple `name_update` to e.g. a dummy `{}` value.
+This can be done by the seller through updating their account name
+(e.g. just to `{}`), or by the buyer by sending one of the CHI inputs
+used back to themselves.
 
-In contrast, the buyer contributes one or multiple coin inputs.  Thus their
-wallet would need to keep track of the inputs into each trade and then spend
-the correct one back to themselves for cancelling the transaction.  While
-in theory possible as well, this is more complicated and less
-straight-forward to do.
-
-A seller might even decide not to cancel a trade and instead simply
-negotiate another one with a different party.  In that case the second
-trade would act as double spend of the first, so that this is always
-safe to do no matter what happens.
+In the context of Democrit, the **taker will be the party that signs first**.
+If the maker would sign first, there would be a potentially long
+period of time during which the order has to be removed from the public
+orderbook, but it is not clear whether or not it is going through; this
+could be abused for DoS attacks thinning out the orderbooks.
+When the taker is required to sign first, the maker only needs to temporarily
+remove the order for a couple of seconds (how long it takes to run the
+automated trade negotiation), and can then be (mostly) sure that it will
+go through since they finalised and broadcast the transaction themselves.
+And if the taker is not providing their signatures within a few seconds
+(which will only be due to either rare technical issues or malice),
+the maker can just abandon the trade without consequences to either party.
 
 ### Tracking of a Trade
 
@@ -104,11 +104,10 @@ and confirmed.  (Even more importantly, they need to know if the trade
 try again with a different party.)
 
 Since they do not have the final transaction, they also do not know the
-txid of it yet (although the wtxid could be used).  Thus, Democrit
-uses a custom dApp / GSP on XAYA to track executed trades.  A seller
-preparing their half of the transaction with a move to send game assets
-will simply include another "move" for Democrit itself, with a unique
-ID:
+txid of it yet (at least not for non-segwit transactions).  Thus, Democrit
+uses a custom dApp / GSP on XAYA to track executed trades.  The user preparing
+the transaction with a move to send game assets
+will simply include another "move" for Democrit itself, with a unique ID:
 
     {
       "g":
@@ -118,9 +117,9 @@ ID:
         }
     }
 
-Here, `abcxyz` is a string that the seller chose by themselves, which should
-be unique at least for the seller's name.  Then, Democrit will track all
-such trades that have gone through, and the seller can query the Democrit game
+Here, `abcxyz` is a string that the taker chooses, which should
+be unique at least for their name.  Then, Democrit will track all
+such trades that have gone through, and the taker can query the Democrit game
 state to see if the particular ID has executed or not.
 
 ## Transaction Fees
@@ -130,8 +129,8 @@ structured.  For instance, the taker of an order could be required to pay it,
 or always the seller (as is typical on various other markets for blockchain
 assets).
 
-However, for Democrit it seems most suitable if *always the buyer* pays
-transaction fees.  Since the buyer is the one funding the transaction
+However, for Democrit it seems most suitable if **always the buyer pays
+transaction fees**.  Since the buyer is the one funding the transaction
 and also in control of how many inputs there will be (and thus how large
 the transaction will end up), it makes the most sense.
 
@@ -148,10 +147,12 @@ channel (or some other broadcast), so that everyone subscribed to the channel
 can construct the *global* order book.
 
 Since all trades are done interactively and thus everyone has to be online,
-we require orders to be published frequently (e.g. once evey ten minutes) for
+we require orders to be published frequently (e.g. once every ten minutes) for
 each user.  Orders of users who have not published an update in e.g. the
 last half an hour will "expire" and no longer be taken into account by
-the other traders.
+the other traders.  If a user disconnects from the broadcast channel,
+their orders will also be removed immediately (e.g. upon receipt of the
+unavailable XMPP presence).
 
 ## Execution of a Trade
 
@@ -160,31 +161,40 @@ Once two users want to execute a trade (e.g. the seller posted an
 communication channel between each other.  Via this communcation channel,
 the following steps are then performed in order to finalise the trade:
 
-1. The seller sends two addresses of their wallet to the buyer,
-   one for the name output and one for receiving the payment in CHI.
+1. The taker initiates the trade by contacting the maker and telling
+   them the order and exact amount of asset they are interested in.
    They also send a string for use as trade ID in the `g/dem` move.  This
    string should be unique for their name (but need not be globally unique).
-1. The buyer constructs the unsigned transaction based on these addresses,
+1. If the taker is the seller, they also send two addresses of their wallet,
+   one for the name output and one for receiving the payment in CHI.
+1. If the maker is the seller, they reply with those two addresses
+   in a follow-up message.
+1. The buyer constructs the unsigned transaction based on the shared data,
    their own inputs and change address, and the move data for the trade.
    They also sign their inputs to the transaction and store the
    signatures locally.
-1. The buyer sends the *unsigned transaction* not including their signatures
-   to the seller.
+1. If the buyer is the taker, they add the signatures and share the
+   partially signed transaction with the seller.  If the buyer is the maker,
+   they share the *unsigned* transaction with the seller.
 1. The seller verifies that the payment and name output are as expected,
    and that the current UTXO of their name is an input to the transaction.
-   Then they sign just that single input and send the partially signed
-   transaction back to the buyer.
-1. The buyer merges in their signatures stored previously and broadcasts
-   the transaction.
+   Then they sign just that single input.
+1. If the seller is the maker, the transaction is now fully signed and
+   can be broadcast.  If the seller is the taker, they send the partially
+   signed transaction back to the buyer.
+1. If the buyer is the maker, they add the previously stored signatures
+   into the transaction and broadcast it.
 
-The seller marks the order as "in progress" when they send their partial
-transaction to the buyer, and then watches the Democrit GSP to see when the
+The taker marks the order as "in progress" when they send their partial
+transaction to the maker, and then watches the Democrit GSP to see when the
 trade goes through based on their chosen trade ID.  If it takes too long,
-they can cancel any time by just updating the name and thus double spending
-the name coin.
-
-The buyer constructs and broadcasts the final transaction, so they can
+they can cancel any time by just double spending one of their inputs
+(CHI or name).
+The maker constructs and broadcasts the final transaction, so they can
 track the progress simply through their wallet.  Thus they can also show the
-trade as "in progress" until it is confirmed.  In case the seller double
-spends, their wallet will mark the transaction as conflicted and they know
-that the trade failed.
+trade as "in progress" until it is confirmed.
+
+Until the trade has gone through, both participants can check all the
+inputs of the transaction on the network to detect a potential double spend
+of any of them.  If this happens, they know the trade failed and their
+client can show it as such.

--- a/gsp/game.hpp
+++ b/gsp/game.hpp
@@ -33,7 +33,7 @@ namespace dem
 
 /**
  * SQLiteGame instance for the Democrit GSP (that just tracks pending / executed
- * trades based on the seller-provided IDs).
+ * trades based on the btxid).
  */
 class DemGame : public xaya::SQLiteGame
 {
@@ -41,11 +41,10 @@ class DemGame : public xaya::SQLiteGame
 private:
 
   /**
-   * Tries to parse and validate a move from the notification JSON object.
+   * Parses a move from the notification JSON object.
    * This is also used for pending moves.
    */
-  static bool ParseMove (const Json::Value& mv, std::string& name,
-                         std::string& tradeId);
+  static void ParseMove (const Json::Value& mv, std::string& btxid);
 
   friend class dem::PendingMoves;
 
@@ -77,10 +76,23 @@ public:
   };
 
   /**
-   * Queries for the state of the trade with given seller name and trade ID.
+   * Data for a particular trade.
    */
-  TradeState CheckTrade (const xaya::Game& g, const std::string& name,
-                         const std::string& tradeId);
+  struct TradeData
+  {
+
+    /** The state of the trade.  */
+    TradeState state;
+
+    /** If the trade is confirmed, the height at which it was confirmed.  */
+    unsigned confirmationHeight;
+
+  };
+
+  /**
+   * Queries for the state of the trade with given btxid.
+   */
+  TradeData CheckTrade (const xaya::Game& g, const std::string& btxid);
 
 };
 

--- a/gsp/main.cpp
+++ b/gsp/main.cpp
@@ -107,6 +107,10 @@ main (int argc, char** argv)
   config.EnablePruning = FLAGS_enable_pruning;
   config.DataDirectory = FLAGS_datadir;
 
+  /* We need support of the btxid, from https://github.com/xaya/xaya/pull/105.
+     This is included in 1.5 and up.  */
+  config.MinXayaVersion = 1050000;
+
   dem::DemGame logic;
   InstanceFactory instanceFact(logic);
   config.InstanceFactory = &instanceFact;

--- a/gsp/pending.cpp
+++ b/gsp/pending.cpp
@@ -40,22 +40,10 @@ PendingMoves::ToJson () const
 void
 PendingMoves::AddPendingMove (const Json::Value& mv)
 {
-  std::string name, tradeId;
-  if (!DemGame::ParseMove (mv, name, tradeId))
-    {
-      LOG (WARNING) << "Invalid pending move: " << mv;
-      return;
-    }
+  std::string btxid;
+  DemGame::ParseMove (mv, btxid);
 
-  if (!pending.isMember (name))
-    pending[name] = Json::Value (Json::arrayValue);
-  auto& arr = pending[name];
-  CHECK (arr.isArray ());
-
-  for (const auto& existing : arr)
-    if (existing.asString () == tradeId)
-      return;
-  arr.append (tradeId);
+  pending[btxid] = Json::Value (Json::objectValue);
 }
 
 } // namespace dem

--- a/gsp/pending.hpp
+++ b/gsp/pending.hpp
@@ -36,8 +36,6 @@ private:
 
   /**
    * The current pending state.  It is already in the JSON form for simplicity.
-   * We can still look up by name efficiently, and then just need to iterate
-   * through all open trades of a single name (which shouldn't be many anyway).
    */
   Json::Value pending;
 

--- a/gsp/rpc-stubs/gsp.json
+++ b/gsp/rpc-stubs/gsp.json
@@ -16,11 +16,7 @@
 
   {
     "name": "checktrade",
-    "params":
-      {
-        "name": "foo",
-        "tradeid": "bar"
-      },
-    "returns": "state"
+    "params": ["btxid"],
+    "returns": {}
   }
 ]

--- a/gsp/rpcserver.cpp
+++ b/gsp/rpcserver.cpp
@@ -44,21 +44,30 @@ RpcServer::getpendingstate ()
   return game.GetPendingJsonState ();
 }
 
-std::string
-RpcServer::checktrade (const std::string& name, const std::string& tradeId)
+Json::Value
+RpcServer::checktrade (const std::string& btxid)
 {
-  LOG (INFO) << "RPC method called: checktrade " << name << " " << tradeId;
-  switch (logic.CheckTrade (game, name, tradeId))
+  LOG (INFO) << "RPC method called: checktrade " << btxid;
+  const auto data = logic.CheckTrade (game, btxid);
+
+  Json::Value res(Json::objectValue);
+  switch (data.state)
     {
     case DemGame::TradeState::UNKNOWN:
-      return "unknown";
+      res["state"] = "unknown";
+      break;
     case DemGame::TradeState::PENDING:
-      return "pending";
+      res["state"] = "pending";
+      break;
     case DemGame::TradeState::CONFIRMED:
-      return "confirmed";
+      res["state"] = "confirmed";
+      res["height"] = static_cast<Json::Int> (data.confirmationHeight);
+      break;
     default:
       LOG (FATAL) << "Unexpected trade state";
     }
+
+  return res;
 }
 
 } // namespace dem

--- a/gsp/rpcserver.hpp
+++ b/gsp/rpcserver.hpp
@@ -56,8 +56,7 @@ public:
   Json::Value getcurrentstate () override;
   Json::Value getpendingstate () override;
 
-  std::string checktrade (const std::string& name,
-                          const std::string& tradeId) override;
+  Json::Value checktrade (const std::string& btxid) override;
 
 };
 


### PR DESCRIPTION
This updates the protocol for trades (as described in `README`) and the Democrit GSP to match it.  The main changes are that the taker signs "first" (rather than the seller) to prevent some DoS attack vectors, that we use the [`btxid`](https://github.com/xaya/xaya/pull/105) rather than a user-provided string to track trades, and that we include steps to lock/unlock the outputs used in a current trade in the wallet in the documentation.