### PR TITLE
Implement trading work flow

### DIFF
--- a/nonfungible/main.cpp
+++ b/nonfungible/main.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -42,6 +42,11 @@ using democrit::Asset;
 
 DEFINE_string (gsp_rpc_url, "",
                "URL at which the GSP's JSON-RPC interface is available");
+
+DEFINE_string (xaya_rpc_url, "",
+               "URL at which Xaya's JSON-RPC interface is available");
+DEFINE_string (dem_rpc_url, "",
+               "URL at which the Democrit GSP's RPC interface is available");
 
 DEFINE_int32 (rpc_port, 0,
               "the port at which Democrit's JSON-RPC server will be started");
@@ -193,6 +198,10 @@ main (int argc, char** argv)
     {
       if (FLAGS_gsp_rpc_url.empty ())
         throw UsageError ("--gsp_rpc_url must be set");
+      if (FLAGS_xaya_rpc_url.empty ())
+        throw UsageError ("--xaya_rpc_url must be set");
+      if (FLAGS_dem_rpc_url.empty ())
+        throw UsageError ("--dem_rpc_url must be set");
 
       if (FLAGS_rpc_port == 0)
         throw UsageError ("--rpc_port must be set");
@@ -207,6 +216,7 @@ main (int argc, char** argv)
       NfAssetSpec spec(gsp);
 
       democrit::Daemon daemon(spec, FLAGS_account,
+                              FLAGS_xaya_rpc_url, FLAGS_dem_rpc_url,
                               FLAGS_jid, FLAGS_password, FLAGS_room);
 
       jsonrpc::HttpServer httpServer(FLAGS_rpc_port);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,12 +14,15 @@ PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 EXTRA_DIST = \
   rpc-stubs/daemon.json \
   rpc-stubs/test.json \
+  rpc-stubs/xaya.json \
   $(PROTOS)
 
 RPC_STUBS = \
   rpc-stubs/daemonrpcserverstub.h \
   rpc-stubs/testrpcclient.h \
-  rpc-stubs/testrpcserverstub.h
+  rpc-stubs/testrpcserverstub.h \
+  rpc-stubs/xayarpcclient.h \
+  rpc-stubs/xayarpcserverstub.h
 BUILT_SOURCES = $(PROTOHEADERS) $(RPC_STUBS)
 CLEANFILES = $(PROTOHEADERS) $(PROTOSOURCES) $(RPC_STUBS)
 
@@ -74,6 +77,7 @@ tests_LDADD = \
   $(CHARON_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS) \
   $(PROTOBUF_LIBS) $(GTEST_LIBS)
 tests_SOURCES = \
+  mockxaya.cpp \
   testutils.cpp \
   \
   authenticator_tests.cpp \
@@ -87,6 +91,7 @@ tests_SOURCES = \
   stanzas_tests.cpp \
   trades_tests.cpp
 check_HEADERS = \
+  mockxaya.hpp mockxaya.tpp \
   testutils.hpp
 
 proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
@@ -99,3 +104,8 @@ rpc-stubs/testrpcclient.h: $(srcdir)/rpc-stubs/test.json
 	jsonrpcstub "$<" --cpp-client=TestRpcClient --cpp-client-file="$@"
 rpc-stubs/testrpcserverstub.h: $(srcdir)/rpc-stubs/test.json
 	jsonrpcstub "$<" --cpp-server=TestRpcServerStub --cpp-server-file="$@"
+
+rpc-stubs/xayarpcclient.h: $(srcdir)/rpc-stubs/xaya.json
+	jsonrpcstub "$<" --cpp-client=XayaRpcClient --cpp-client-file="$@"
+rpc-stubs/xayarpcserverstub.h: $(srcdir)/rpc-stubs/xaya.json
+	jsonrpcstub "$<" --cpp-server=XayaRpcServerStub --cpp-server-file="$@"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ libdemocrit_la_SOURCES = \
   orderbook.cpp \
   rpcserver.cpp \
   stanzas.cpp \
+  trades.cpp \
   $(PROTOSOURCES)
 democrit_HEADERS = \
   assetspec.hpp \
@@ -56,7 +57,8 @@ noinst_HEADERS = \
   private/orderbook.hpp \
   private/rpcclient.hpp private/rpcclient.tpp \
   private/stanzas.hpp stanzas.tpp \
-  private/state.hpp
+  private/state.hpp \
+  private/trades.hpp
 
 check_PROGRAMS = tests
 TESTS = tests
@@ -81,7 +83,8 @@ tests_SOURCES = \
   myorders_tests.cpp \
   orderbook_tests.cpp \
   rpcclient_tests.cpp \
-  stanzas_tests.cpp
+  stanzas_tests.cpp \
+  trades_tests.cpp
 check_HEADERS = \
   testutils.hpp
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,12 +13,15 @@ PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 
 EXTRA_DIST = \
   rpc-stubs/daemon.json \
+  rpc-stubs/dem-gsp.json \
   rpc-stubs/test.json \
   rpc-stubs/xaya.json \
   $(PROTOS)
 
 RPC_STUBS = \
   rpc-stubs/daemonrpcserverstub.h \
+  rpc-stubs/demgsprpcclient.h \
+  rpc-stubs/demgsprpcserverstub.h \
   rpc-stubs/testrpcclient.h \
   rpc-stubs/testrpcserverstub.h \
   rpc-stubs/xayarpcclient.h \
@@ -102,6 +105,11 @@ proto/%.pb.h proto/%.pb.cc: $(srcdir)/proto/%.proto
 
 rpc-stubs/daemonrpcserverstub.h: $(srcdir)/rpc-stubs/daemon.json
 	jsonrpcstub "$<" --cpp-server=DaemonRpcServerStub --cpp-server-file="$@"
+
+rpc-stubs/demgsprpcclient.h: $(srcdir)/rpc-stubs/dem-gsp.json
+	jsonrpcstub "$<" --cpp-client=DemGspRpcClient --cpp-client-file="$@"
+rpc-stubs/demgsprpcserverstub.h: $(srcdir)/rpc-stubs/dem-gsp.json
+	jsonrpcstub "$<" --cpp-server=DemGspRpcServerStub --cpp-server-file="$@"
 
 rpc-stubs/testrpcclient.h: $(srcdir)/rpc-stubs/test.json
 	jsonrpcstub "$<" --cpp-client=TestRpcClient --cpp-client-file="$@"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,8 @@ rpcstubdir = $(democritdir)/rpc-stubs
 
 PROTOS = \
   proto/orders.proto \
-  proto/state.proto
+  proto/state.proto \
+  proto/trades.proto
 PROTOHEADERS = $(PROTOS:.proto=.pb.h)
 PROTOSOURCES = $(PROTOS:.proto=.pb.cc)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@ rpcstubdir = $(democritdir)/rpc-stubs
 
 PROTOS = \
   proto/orders.proto \
+  proto/processing.proto \
   proto/state.proto \
   proto/trades.proto
 PROTOHEADERS = $(PROTOS:.proto=.pb.h)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ libdemocrit_la_LIBADD = \
   $(PROTOBUF_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS)
 libdemocrit_la_SOURCES = \
   authenticator.cpp \
+  checker.cpp \
   daemon.cpp \
   intervaljob.cpp \
   json.cpp \
@@ -55,6 +56,7 @@ proto_HEADERS = $(PROTOHEADERS)
 rpcstub_HEADERS = $(RPC_STUBS)
 noinst_HEADERS = \
   private/authenticator.hpp \
+  private/checker.hpp \
   private/intervaljob.hpp \
   private/mucclient.hpp \
   private/myorders.hpp \
@@ -68,19 +70,20 @@ check_PROGRAMS = tests
 TESTS = tests
 
 tests_CXXFLAGS = \
+  $(CHARON_CFLAGS) $(XAYAGAME_CFLAGS) \
   $(JSON_CFLAGS) $(JSONRPCCPPCLIENT_CFLAGS) $(JSONRPCCPPSERVER_CFLAGS) \
-  $(CHARON_CFLAGS) $(GFLAGS_CFLAGS) $(GLOG_CFLAGS) \
-  $(PROTOBUF_CFLAGS) $(GTEST_CFLAGS)
+  $(PROTOBUF_CFLAGS) $(GFLAGS_CFLAGS) $(GLOG_CFLAGS) $(GTEST_CFLAGS)
 tests_LDADD = \
   $(builddir)/libdemocrit.la \
+  $(CHARON_LIBS) $(XAYAGAME_LIBS) \
   $(JSON_LIBS) $(JSONRPCCPPCLIENT_LIBS) $(JSONRPCCPPSERVER_LIBS) \
-  $(CHARON_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS) \
-  $(PROTOBUF_LIBS) $(GTEST_LIBS)
+  $(PROTOBUF_LIBS) $(GFLAGS_LIBS) $(GLOG_LIBS) $(GTEST_LIBS)
 tests_SOURCES = \
   mockxaya.cpp \
   testutils.cpp \
   \
   authenticator_tests.cpp \
+  checker_tests.cpp \
   daemon_tests.cpp \
   intervaljob_tests.cpp \
   json_tests.cpp \

--- a/src/authenticator.cpp
+++ b/src/authenticator.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -175,7 +175,23 @@ Authenticator::Authenticate (const gloox::JID& jid, std::string& account) const
   if (xidServers.count (jid.server ()) == 0)
     return false;
 
-  return DecodeName (jid.username (), account);
+  if (!DecodeName (jid.username (), account))
+    return false;
+
+  VLOG (1) << "JID for account " << account << ": " << jid.full ();
+  knownJids[account] = jid;
+  return true;
+}
+
+bool
+Authenticator::LookupJid (const std::string& account, gloox::JID& jid) const
+{
+  const auto mit = knownJids.find (account);
+  if (mit == knownJids.end ())
+    return false;
+
+  jid = mit->second;
+  return true;
 }
 
 } // namespace democrit

--- a/src/authenticator_tests.cpp
+++ b/src/authenticator_tests.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -66,6 +66,15 @@ protected:
     ASSERT_TRUE (auth->Authenticate (gloox::JID (jid), decoded))
         << "Expected to be valid: " << jid;
     EXPECT_EQ (decoded, expected);
+  }
+
+  /**
+   * Exposes the authenticator instance to tests.
+   */
+  const Authenticator&
+  GetAuth () const
+  {
+    return *auth;
   }
 
 };
@@ -139,6 +148,24 @@ TEST_F (AuthenticatorTests, HexEncodedNames)
   ExpectValid ("x-782d666f6f@server", "x-foo");
   ExpectValid ("x-c3a4c3b6c3bc@server", u8"äöü");
   ExpectValid ("x-466f6f20426172@server", "Foo Bar");
+}
+
+TEST_F (AuthenticatorTests, LookupJid)
+{
+  SetServers ("server1,server2");
+
+  gloox::JID jid;
+  EXPECT_FALSE (GetAuth ().LookupJid ("domob", jid));
+  EXPECT_FALSE (GetAuth ().LookupJid (u8"äöü", jid));
+
+  ExpectValid ("domob@server1/foo", "domob");
+  ExpectValid ("x-c3a4c3b6c3bc@server2/bar", u8"äöü");
+
+  ASSERT_TRUE (GetAuth ().LookupJid ("domob", jid));
+  EXPECT_EQ (jid, "domob@server1/foo");
+  ASSERT_TRUE (GetAuth ().LookupJid (u8"äöü", jid));
+  EXPECT_EQ (jid, "x-c3a4c3b6c3bc@server2/bar");
+  ASSERT_FALSE (GetAuth ().LookupJid ("abc", jid));
 }
 
 } // anonymous namespace

--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -1,0 +1,204 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/checker.hpp"
+
+#include <xayautil/uint256.hpp>
+
+#include <json/json.h>
+
+#include <glog/logging.h>
+
+namespace democrit
+{
+
+namespace
+{
+
+/**
+ * How many blocks back we check when trying to match up the GSP block
+ * and the block at which we queried the name UTXO.  Typically they will match
+ * directly, but to allow for race conditions with new blocks arriving in
+ * between, we check some blocks back.  There is no need to check too many.
+ */
+constexpr int MAX_BLOCK_ANCESTORS_CHECKED = 3;
+
+/**
+ * Returns the full Xaya name (for name operations / lookups) corresponding
+ * to a given acount name.
+ */
+std::string
+GetXayaName (const std::string& account)
+{
+  return "p/" + account;
+}
+
+} // anonymous namespace
+
+std::string
+TradeChecker::GetNameUpdateValue () const
+{
+  Json::Value g(Json::objectValue);
+  g[spec.GetGameId ()] = spec.GetTransferMove (seller, buyer, asset, units);
+  g["dem"] = Json::Value (Json::objectValue);
+
+  Json::Value mv(Json::objectValue);
+  mv["g"] = g;
+
+  Json::StreamWriterBuilder wbuilder;
+  wbuilder["commentStyle"] = "None";
+  wbuilder["indentation"] = "";
+  wbuilder["enableYAMLCompatibility"] = false;
+  wbuilder["dropNullPlaceholders"] = false;
+  wbuilder["useSpecialFloats"] = false;
+
+  return Json::writeString (wbuilder, mv);
+}
+
+namespace
+{
+
+/**
+ * Checks if the given ancestor block hash is indeed an ancestor of the
+ * given child block, according to the Xaya RPC interface.  We check at most
+ * n blocks back.
+ */
+bool
+IsBlockAncestor (RpcClient<XayaRpcClient>& rpc,
+                 const xaya::uint256& ancestor,
+                 const xaya::uint256& child,
+                 const int n)
+{
+  if (ancestor == child)
+    return true;
+
+  if (n == 0)
+    return false;
+  CHECK_GT (n, 0);
+
+  const auto childData = rpc->getblockheader (child.ToHex ());
+  CHECK (childData.isObject ());
+  const auto prevVal = childData["previousblockhash"];
+  if (prevVal.isNull ())
+    {
+      /* This is the case for the genesis block.  */
+      return false;
+    }
+  CHECK (prevVal.isString ());
+  xaya::uint256 parent;
+  CHECK (parent.FromHex (prevVal.asString ()))
+      << "getblockheader prev block hash is not valid uint256: "
+      << childData;
+
+  return IsBlockAncestor (rpc, ancestor, parent, n - 1);
+}
+
+} // anonymous namespace
+
+bool
+TradeChecker::CheckForBuyerTrade (proto::OutPoint& nameInput) const
+{
+  if (!spec.IsAsset (asset))
+    {
+      LOG (WARNING) << "Not a valid asset: " << asset;
+      return false;
+    }
+
+  if (!spec.CanBuy (buyer, asset, units))
+    {
+      LOG (WARNING) << buyer << " cannot receive " << units << " of " << asset;
+      return false;
+    }
+
+  /* We first query for the name output with name_show, and then look up
+     that output with gettxout.  The latter gives us the current block hash,
+     confirming that the name output was still current at that block hash.
+
+     Then we query the GSP (via AssetSpec), which should confirm that the
+     seller can send the assets at the current block.  To verify that the name
+     output matches to the GSP state (i.e. was created *before* the GSP state
+     we checked), we then make sure the block hash of the name output (from
+     gettxout) is the same or one of the last few parent blocks of the
+     GSP-returned block hash.  If it is, then all is good.
+
+     This method is correct, because we require (from AssetSpec) that
+     the result of CanSell must not change unless an explicit name update
+     is done with the seller's name.  Thus if CanSell returns true at a block
+     later than when the name output was created, then it will be true for
+     any block provided the name is not updated.  So either the trade will
+     be valid, or the transaction will be invalid anyway because the name input
+     we use is double-spent on the blockchain level.
+
+     This may produce spurious failures in same rare circumstances, like
+     when still syncing up or when a reorg happens between the calls.  In those
+     cases, we just fail the check and abandon the trade; that should not
+     have a lot of impact.  During normal operation, the block hashes
+     will most likely actually be identical, or at the most e.g. one new
+     block has been attached between the gettxout call and the GSP check.  */
+
+  const auto nameData = xaya->name_show (GetXayaName (seller));
+  CHECK (nameData.isObject ());
+  const auto txidVal = nameData["txid"];
+  CHECK (txidVal.isString ());
+  const auto voutVal = nameData["vout"];
+  CHECK (voutVal.isUInt ());
+  nameInput.Clear ();
+  nameInput.set_hash (txidVal.asString ());
+  nameInput.set_n (voutVal.asUInt ());
+
+  /* gettxout returns a JSON object when the UTXO is found, or JSON null
+     if it does not exist.  libjson-rpc-cpp's generated code does not
+     allow having differing return types, though.  So we need to call the
+     method directly.  */
+  Json::Value params(Json::arrayValue);
+  params.append (nameInput.hash ());
+  params.append (nameInput.n ());
+  const auto utxoData = xaya->CallMethod ("gettxout", params);
+  if (utxoData.isNull ())
+    {
+      LOG (WARNING)
+          << "UTXO from name_show is not found; still syncing?\n"
+          << nameData;
+      return false;
+    }
+  CHECK (utxoData.isObject ());
+  const auto utxoBlockVal = utxoData["bestblock"];
+  CHECK (utxoBlockVal.isString ());
+  xaya::uint256 utxoBlock;
+  CHECK (utxoBlock.FromHex (utxoBlockVal.asString ()))
+      << "gettxout 'bestblock' is not valid hash: " << utxoBlockVal;
+
+  xaya::uint256 gspBlock;
+  if (!spec.CanSell (seller, asset, units, gspBlock))
+    {
+      LOG (WARNING) << seller << " cannot send " << units << " of " << asset;
+      return false;
+    }
+
+  if (!IsBlockAncestor (xaya, utxoBlock, gspBlock, MAX_BLOCK_ANCESTORS_CHECKED))
+    {
+      LOG (WARNING)
+          << "UTXO block is not ancestor of GSP block; still syncing?\n"
+          << utxoBlock.ToHex () << " vs\n" << gspBlock.ToHex ();
+      return false;
+    }
+
+  return true;
+}
+
+} // namespace democrit

--- a/src/checker_tests.cpp
+++ b/src/checker_tests.cpp
@@ -1,0 +1,196 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/checker.hpp"
+
+#include "mockxaya.hpp"
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace democrit
+{
+namespace
+{
+
+DEFINE_PROTO_MATCHER (EqualsOutPoint, OutPoint)
+
+/* ************************************************************************** */
+
+class TradeCheckerTests : public testing::Test
+{
+
+protected:
+
+  TestEnvironment<MockXayaRpcServer> env;
+  TestAssets spec;
+
+  TradeChecker checker;
+
+  TradeCheckerTests ()
+    : checker(spec, env.GetXayaRpc (), "buyer", "seller", "gold", 3)
+  {
+    /* By default, the setting is such that the game allows the trade.  Tests
+       for this will overwrite the data as needed.  */
+    spec.InitialiseAccount ("buyer");
+    spec.SetBalance ("seller", "gold", 10);
+  }
+
+  /**
+   * Sets the best block hash in both the asset spec (GSP) and the mock xaya
+   * RPC server to the block hash at the given height.
+   */
+  void
+  SetBestBlock (const unsigned h)
+  {
+    const auto hash = env.GetXayaServer ().GetBlockHash (h);
+    env.GetXayaServer ().SetBestBlock (hash);
+    spec.SetBlock (hash);
+  }
+
+};
+
+TEST_F (TradeCheckerTests, NameUpdateValue)
+{
+  EXPECT_EQ (
+      checker.GetNameUpdateValue (),
+      R"({"g":{"dem":{},"test":{"amount":3,"asset":"gold","to":"buyer"}}})");
+}
+
+/* ************************************************************************** */
+
+class TradeCheckerForBuyerTests : public TradeCheckerTests
+{
+
+protected:
+
+  /**
+   * Expects that the checker returns that its trade is invalid for
+   * the buyer.
+   */
+  static void
+  ExpectInvalid (const TradeChecker& checker)
+  {
+    proto::OutPoint nameInput;
+    EXPECT_FALSE (checker.CheckForBuyerTrade (nameInput));
+  }
+
+  /**
+   * Expects that the checker returns that its trade is valid for the buyer.
+   * The method returns the name outpoint checked.
+   */
+  static proto::OutPoint
+  ExpectValid (const TradeChecker& checker)
+  {
+    proto::OutPoint nameInput;
+    EXPECT_TRUE (checker.CheckForBuyerTrade (nameInput));
+    return nameInput;
+  }
+
+};
+
+TEST_F (TradeCheckerForBuyerTests, InvalidAsset)
+{
+  TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "invalid", 1);
+  ExpectInvalid (c);
+}
+
+TEST_F (TradeCheckerForBuyerTests, BuyerCannotReceive)
+{
+  TradeChecker c(spec, env.GetXayaRpc (), "uninit", "seller", "gold", 1);
+  ExpectInvalid (c);
+}
+
+TEST_F (TradeCheckerForBuyerTests, NameUtxoDoesNotExist)
+{
+  /* This test simulates a situation where name_show returns an outpoint
+     that is not a valid UTXO, e.g. because the name has just been updated.  */
+  ExpectInvalid (checker);
+}
+
+TEST_F (TradeCheckerForBuyerTests, SellerCannotSend)
+{
+  SetBestBlock (10);
+  env.GetXayaServer ().AddUtxo ("seller txid", 12);
+  spec.SetBalance ("seller", "gold", 2);
+  ExpectInvalid (checker);
+}
+
+TEST_F (TradeCheckerForBuyerTests, NameNotAnAncestor)
+{
+  /* This situation may happen in practice if there is a reorg or something
+     around the time when the name output from the UTXO set and the GSP
+     are queried.  This is unlikely to happen in practice, but makes it
+     impossible (with the current implementation at least) to prove
+     that the trade is safe.
+
+     In the more typical case that the seller tries to cheat by "double
+     spending" the assets while the trade is going on, we will most likely
+     fail instead with "cannot send" or actually construct the transaction
+     but it won't confirm since the name input itself is double-spent on the
+     blockchain level.
+
+     The ancestor check is still important, to catch e.g. the following
+     situation:  Let's say, the seller spends the assets being traded with
+     a name update in block N.  But for some reason, the GSP is at block N-1
+     when we query it (e.g. because it lags behind or there is a reorg).
+     Then without the ancestor check, we might see that the asset can be
+     sold (at block N-1) and construct a transaction using the new name output
+     from block N, which would lead to an invalid trade.  */
+
+  spec.SetBlock (env.GetXayaServer ().GetBlockHash (10));
+  env.GetXayaServer ().SetBestBlock (env.GetXayaServer ().GetBlockHash (11));
+
+  env.GetXayaServer ().AddUtxo ("seller txid", 12);
+  ExpectInvalid (checker);
+}
+
+TEST_F (TradeCheckerForBuyerTests, AncestorCheckHitsGenesis)
+{
+  spec.SetBlock (env.GetXayaServer ().GetBlockHash (2));
+  env.GetXayaServer ().SetBestBlock (env.GetXayaServer ().GetBlockHash (10));
+
+  env.GetXayaServer ().AddUtxo ("seller txid", 12);
+  ExpectInvalid (checker);
+}
+
+TEST_F (TradeCheckerForBuyerTests, ValidSameBlock)
+{
+  SetBestBlock (10);
+  env.GetXayaServer ().AddUtxo ("seller txid", 12);
+
+  const auto outpoint = ExpectValid (checker);
+  EXPECT_THAT (outpoint, EqualsOutPoint (R"(
+    hash: "seller txid"
+    n: 12
+  )"));
+}
+
+TEST_F (TradeCheckerForBuyerTests, ValidAncestorBlock)
+{
+  spec.SetBlock (env.GetXayaServer ().GetBlockHash (10));
+  env.GetXayaServer ().SetBestBlock (env.GetXayaServer ().GetBlockHash (7));
+
+  env.GetXayaServer ().AddUtxo ("seller txid", 12);
+  ExpectValid (checker);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace democrit

--- a/src/checker_tests.cpp
+++ b/src/checker_tests.cpp
@@ -21,7 +21,11 @@
 #include "mockxaya.hpp"
 #include "testutils.hpp"
 
+#include <xayautil/jsonutils.hpp>
+
 #include <gtest/gtest.h>
+
+#include <limits>
 
 namespace democrit
 {
@@ -43,7 +47,7 @@ protected:
   TradeChecker checker;
 
   TradeCheckerTests ()
-    : checker(spec, env.GetXayaRpc (), "buyer", "seller", "gold", 3)
+    : checker(spec, env.GetXayaRpc (), "buyer", "seller", "gold", 10, 3)
   {
     /* By default, the setting is such that the game allows the trade.  Tests
        for this will overwrite the data as needed.  */
@@ -70,6 +74,40 @@ TEST_F (TradeCheckerTests, NameUpdateValue)
   EXPECT_EQ (
       checker.GetNameUpdateValue (),
       R"({"g":{"dem":{},"test":{"amount":3,"asset":"gold","to":"buyer"}}})");
+}
+
+TEST_F (TradeCheckerTests, GetTotalSat)
+{
+  struct Test
+  {
+    Amount price;
+    Amount units;
+    bool expectedSuccess;
+    Amount expectedTotal = 0;
+  };
+
+  static const Test tests[] =
+    {
+      {2, 3, true, 6},
+      {0, 42, true, 0},
+      {
+        std::numeric_limits<Amount>::max (),
+        std::numeric_limits<Amount>::max (),
+        false,
+      },
+    };
+
+  for (const auto& t : tests)
+    {
+      const TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "gold",
+                           t.price, t.units);
+      Amount res;
+      ASSERT_EQ (c.GetTotalSat (res), t.expectedSuccess);
+      if (t.expectedSuccess)
+        {
+          ASSERT_EQ (res, t.expectedTotal);
+        }
+    }
 }
 
 /* ************************************************************************** */
@@ -106,13 +144,13 @@ protected:
 
 TEST_F (TradeCheckerForBuyerTests, InvalidAsset)
 {
-  TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "invalid", 1);
+  TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "invalid", 1, 1);
   ExpectInvalid (c);
 }
 
 TEST_F (TradeCheckerForBuyerTests, BuyerCannotReceive)
 {
-  TradeChecker c(spec, env.GetXayaRpc (), "uninit", "seller", "gold", 1);
+  TradeChecker c(spec, env.GetXayaRpc (), "uninit", "seller", "gold", 1, 1);
   ExpectInvalid (c);
 }
 
@@ -188,6 +226,276 @@ TEST_F (TradeCheckerForBuyerTests, ValidAncestorBlock)
 
   env.GetXayaServer ().AddUtxo ("seller txid", 12);
   ExpectValid (checker);
+}
+
+/* ************************************************************************** */
+
+class TradeCheckerForSellerOutputsTests : public TradeCheckerTests
+{
+
+protected:
+
+  /**
+   * Returns the checker's expected name-update value as JSON string literal
+   * (so it can be concatenated into the JSON string).
+   */
+  static std::string
+  GetUpdateLiteral (const TradeChecker& c)
+  {
+    const Json::Value val = c.GetNameUpdateValue ();
+    std::ostringstream out;
+    out << val;
+    return out.str ();
+  }
+
+  /**
+   * Returns a minimal JSON "vout" value which will check to valid.  The CHI
+   * output will be index 0 and the name output index 1.
+   */
+  static Json::Value
+  GetValidVout (const TradeChecker& c)
+  {
+    Amount total;
+    CHECK (c.GetTotalSat (total));
+
+    std::ostringstream chiValue;
+    chiValue << xaya::ChiAmountToJson (total);
+
+    return ParseJson (R"([
+      {
+        "value": )" + chiValue.str () + R"(,
+        "scriptPubKey":
+          {
+            "addresses": ["chi addr"]
+          }
+      },
+      {
+        "value": 0.01000000,
+        "scriptPubKey":
+          {
+            "addresses": ["name addr"],
+            "nameOp":
+              {
+                "op": "name_update",
+                "name_encoding": "utf8",
+                "value_encoding": "ascii",
+                "name": "p/seller",
+                "value": )" + GetUpdateLiteral (c) + R"(
+              }
+          }
+      }
+    ])");
+  }
+
+  /**
+   * Calls CheckForSellerOutputs with a PSBT whose ["tx"]["vout"] matches the
+   * given decoded JSON.
+   */
+  bool
+  Check (TradeChecker& c, const proto::SellerData& sd, const Json::Value& vout)
+  {
+    CHECK (vout.isArray ());
+
+    Json::Value tx(Json::objectValue);
+    tx["vout"] = vout;
+    Json::Value psbt(Json::objectValue);
+    psbt["tx"] = tx;
+
+    env.GetXayaServer ().SetPsbt ("psbt", psbt);
+
+    return c.CheckForSellerOutputs ("psbt", sd);
+  }
+
+  /**
+   * Like Check with explicit seller data, but setting "chi addr" and
+   * "name addr" for the addresses we expect.
+   */
+  bool
+  Check (TradeChecker& c, const Json::Value& vout)
+  {
+    const auto sd = ParseTextProto<proto::SellerData> (R"(
+      chi_address: "chi addr"
+      name_address: "name addr"
+    )");
+
+    return Check (c, sd, vout);
+  }
+
+};
+
+TEST_F (TradeCheckerForSellerOutputsTests, Valid)
+{
+  EXPECT_TRUE (Check (checker, GetValidVout (checker)));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, LargerPaymentOk)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[0]["value"] = 0.5;
+  EXPECT_TRUE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ExtraOutputOk)
+{
+  auto vouts = GetValidVout (checker);
+  vouts.append (ParseJson (R"({
+    "value": 10.0,
+    "scriptPubKey":
+      {
+        "addresses": ["change addr"]
+      }
+  })"));
+  EXPECT_TRUE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ZeroTotalNeedsNoChiOutput)
+{
+  TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "gold", 0, 1);
+
+  const auto baseVouts = GetValidVout (c);
+  Json::Value vouts(Json::arrayValue);
+  vouts.append (baseVouts[1]);
+
+  EXPECT_TRUE (Check (c, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ChiAndNameSameAddress)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[0]["scriptPubKey"]["addresses"][0] = "addr";
+  vouts[1]["scriptPubKey"]["addresses"][0] = "addr";
+
+  const auto sd = ParseTextProto<proto::SellerData> (R"(
+    chi_address: "addr"
+    name_address: "addr"
+  )");
+
+  EXPECT_TRUE (Check (checker, sd, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, TotalOverflow)
+{
+  const auto max = std::numeric_limits<Amount>::max ();
+  TradeChecker c(spec, env.GetXayaRpc (), "buyer", "seller", "gold", max, 2);
+
+  Json::Value vouts = GetValidVout (checker);
+  vouts[0]["value"] = 10.0 * max;
+
+  EXPECT_FALSE (Check (c, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, InvalidScriptPubKeyAddresses)
+{
+  const auto baseVouts = GetValidVout (checker);
+
+  auto vouts = baseVouts;
+  vouts[0]["scriptPubKey"] = Json::Value (Json::objectValue);
+  EXPECT_FALSE (Check (checker, vouts));
+
+  vouts = baseVouts;
+  vouts[0]["scriptPubKey"]["addresses"].append ("foo");
+  EXPECT_FALSE (Check (checker, vouts));
+
+  vouts = baseVouts;
+  vouts[0]["scriptPubKey"]["addresses"] = "chi addr";
+  EXPECT_FALSE (Check (checker, vouts));
+
+  vouts = baseVouts;
+  vouts[0]["scriptPubKey"]["addresses"] = 42;
+  EXPECT_FALSE (Check (checker, vouts));
+
+  vouts = baseVouts;
+  vouts[0]["scriptPubKey"]["addresses"] = Json::Value (Json::arrayValue);
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ChiOutputMissing)
+{
+  const auto baseVouts = GetValidVout (checker);
+  Json::Value vouts(Json::arrayValue);
+  vouts.append (baseVouts[1]);
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ChiOutputWrongAddress)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[0]["scriptPubKey"]["addresses"][0] = "foo";
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ChiOutputTooLittle)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[0]["value"] = 0.00000029;
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, ChiOutputSplit)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[0]["value"] = 0.00000015;
+  vouts.append (vouts[0]);
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameDoesNotCountForChi)
+{
+  /* In the situation here, the name output goes to the correct CHI address
+     and also pays (inside the name) enough to cover the total.  This is still
+     not an acceptable situation.  */
+
+  const auto baseVouts = GetValidVout (checker);
+  auto vouts = Json::Value (Json::arrayValue);
+  vouts.append (baseVouts[1]);
+  vouts[0]["scriptPubKey"]["addresses"][0] = "addr";
+  vouts[0]["value"] = 1.0;
+
+  const auto sd = ParseTextProto<proto::SellerData> (R"(
+    chi_address: "addr"
+    name_address: "addr"
+  )");
+
+  EXPECT_FALSE (Check (checker, sd, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameOutputMissing)
+{
+  const auto baseVouts = GetValidVout (checker);
+  Json::Value vouts(Json::arrayValue);
+  vouts.append (baseVouts[0]);
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameOutputWrongAddress)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[1]["scriptPubKey"]["addresses"][0] = "foo";
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameOutputWrongValue)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[1]["scriptPubKey"]["nameOp"]["value"] = "foo";
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameOutputWrongName)
+{
+  /* This is not actually relevant in practice as the seller only signs
+     their real input, and thus if the output is for another name, the
+     transaction itself is wrong.  But let's check anyway.  */
+  auto vouts = GetValidVout (checker);
+  vouts[1]["scriptPubKey"]["nameOp"]["name"] = "p/buyer";
+  EXPECT_FALSE (Check (checker, vouts));
+}
+
+TEST_F (TradeCheckerForSellerOutputsTests, NameOutputWrongOperation)
+{
+  auto vouts = GetValidVout (checker);
+  vouts[1]["scriptPubKey"]["nameOp"]["op"] = "name_register";
+  EXPECT_FALSE (Check (checker, vouts));
 }
 
 /* ************************************************************************** */

--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -44,6 +44,13 @@ DEFINE_int64 (democrit_order_timeout_ms, 10 * 60 * 1'000,
 DEFINE_int64 (democrit_reconnect_ms, 10 * 1'000,
               "Interval (in milliseconds) for trying to reconnect to XMPP");
 
+/**
+ * Whether or not we should use the "legacy" V1 protocol for the Xaya
+ * RPC client.  The real Xaya Core needs it, but in unit tests against our
+ * mock server we want to disable this.
+ */
+bool useLegacyXayaRpcInDaemon = true;
+
 /* ************************************************************************** */
 
 /**
@@ -183,7 +190,7 @@ Daemon::Impl::Impl (const AssetSpec& s, const std::string& account,
     spec(s), state(account),
     myOrders(*this),
     allOrders(std::chrono::milliseconds (FLAGS_democrit_order_timeout_ms)),
-    xayaRpc(xr), demGsp(dg),
+    xayaRpc(xr, useLegacyXayaRpcInDaemon), demGsp(dg),
     trades(state, myOrders, spec, xayaRpc, demGsp, true)
 {
   std::string jidAccount;

--- a/src/daemon.hpp
+++ b/src/daemon.hpp
@@ -29,6 +29,8 @@
 namespace democrit
 {
 
+class State;
+
 /**
  * The main class for running a Democrit daemon.  It manages all the things
  * needed for it, like the underlying XMPP client connection, the processes
@@ -52,6 +54,14 @@ private:
    * file to decouple the public interface from internal stuff.
    */
   std::unique_ptr<Impl> impl;
+
+  /**
+   * Returns the internal state class held by the daemon instance.  This is
+   * used in tests.
+   */
+  State& GetStateForTesting ();
+
+  friend class TestDaemon;
 
 public:
 

--- a/src/daemon.hpp
+++ b/src/daemon.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 
 #include "assetspec.hpp"
 #include "proto/orders.pb.h"
+#include "proto/trades.pb.h"
 
 #include <memory>
 #include <string>
@@ -55,6 +56,7 @@ private:
 public:
 
   explicit Daemon (const AssetSpec& spec, const std::string& account,
+                   const std::string& xayaRpc, const std::string& demGspRpc,
                    const std::string& jid, const std::string& password,
                    const std::string& mucRoom);
 
@@ -91,6 +93,18 @@ public:
    * Returns the own orders currently being advertised.
    */
   proto::OrdersOfAccount GetOwnOrders () const;
+
+  /**
+   * Returns the list of known trades.
+   */
+  std::vector<proto::Trade> GetTrades () const;
+
+  /**
+   * Requests to take another's order for the given number of units.
+   * Returns true on success (if the process could at least be started)
+   * and false if something failed right away.
+   */
+  bool TakeOrder (const proto::Order& o, Amount units);
 
   /**
    * Returns the account name this is running for.

--- a/src/daemon_tests.cpp
+++ b/src/daemon_tests.cpp
@@ -37,6 +37,8 @@ namespace democrit
 DECLARE_string (democrit_xid_servers);
 DECLARE_int64 (democrit_order_timeout_ms);
 
+extern bool useLegacyXayaRpcInDaemon;
+
 namespace
 {
 
@@ -66,6 +68,8 @@ protected:
 
     const std::chrono::milliseconds timeoutMs(TIMEOUT);
     FLAGS_democrit_order_timeout_ms = timeoutMs.count ();
+
+    useLegacyXayaRpcInDaemon = false;
   }
 
 };

--- a/src/json_tests.cpp
+++ b/src/json_tests.cpp
@@ -19,6 +19,7 @@
 #include "json.hpp"
 
 #include "proto/orders.pb.h"
+#include "proto/trades.pb.h"
 #include "testutils.hpp"
 
 #include <gtest/gtest.h>
@@ -307,6 +308,49 @@ TEST_F (JsonTests, OrderbookByAssetToJson)
             }
           ]
       }
+  })");
+}
+
+TEST_F (JsonTests, TradeToJson)
+{
+  ExpectProtoToJson<proto::Trade> (R"(
+    state: PENDING
+    start_time: 123
+    counterparty: "domob"
+    type: BID
+    asset: "gold"
+    units: 42
+    price_sat: 10
+    role: MAKER
+  )", R"({
+    "state": "pending",
+    "start_time": 123,
+    "counterparty": "domob",
+    "type": "bid",
+    "asset": "gold",
+    "units": 42,
+    "price_sat": 10,
+    "role": "maker"
+  })");
+
+  ExpectProtoToJson<proto::Trade> (R"(
+    state: SUCCESS
+    start_time: 456
+    counterparty: "domob"
+    type: ASK
+    asset: "silver"
+    units: 1
+    price_sat: 100
+    role: TAKER
+  )", R"({
+    "state": "success",
+    "start_time": 456,
+    "counterparty": "domob",
+    "type": "ask",
+    "asset": "silver",
+    "units": 1,
+    "price_sat": 100,
+    "role": "taker"
   })");
 }
 

--- a/src/json_tests.cpp
+++ b/src/json_tests.cpp
@@ -35,18 +35,6 @@ namespace
 
 using google::protobuf::util::MessageDifferencer;
 
-/**
- * Parses a string to JSON.
- */
-Json::Value
-ParseJson (const std::string& str)
-{
-  std::istringstream in(str);
-  Json::Value res;
-  in >> res;
-  return res;
-}
-
 class JsonTests : public testing::Test
 {
 

--- a/src/mockxaya.cpp
+++ b/src/mockxaya.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -44,6 +44,8 @@ GetPortForMockServer ()
 
   return 2'000 + (cnt % 1'000);
 }
+
+/* ************************************************************************** */
 
 MockXayaRpcServer::MockXayaRpcServer (jsonrpc::AbstractServerConnector& conn)
   : XayaRpcServerStub(conn)
@@ -421,5 +423,44 @@ MockXayaRpcServer::finalizepsbt (const std::string& psbt)
 
   return res;
 }
+
+/* ************************************************************************** */
+
+void
+MockDemGsp::SetPending (const std::string& btxid)
+{
+  btxids[btxid] = ParseJson (R"({
+    "state": "pending"
+  })");
+}
+
+void
+MockDemGsp::SetConfirmed (const std::string& btxid, const unsigned h)
+{
+  auto data = ParseJson (R"({
+    "state": "confirmed"
+  })");
+  data["height"] = static_cast<Json::Int> (h);
+  btxids[btxid] = data;
+}
+
+Json::Value
+MockDemGsp::checktrade (const std::string& btxid)
+{
+  Json::Value res(Json::objectValue);
+  res["height"] = static_cast<Json::Int> (currentHeight);
+
+  const auto mit = btxids.find (btxid);
+  if (mit != btxids.end ())
+    res["data"] = mit->second;
+  else
+    res["data"] = ParseJson (R"({
+      "state": "unknown"
+    })");
+
+  return res;
+}
+
+/* ************************************************************************** */
 
 } // namespace democrit

--- a/src/mockxaya.cpp
+++ b/src/mockxaya.cpp
@@ -107,4 +107,13 @@ MockXayaRpcServer::getblockheader (const std::string& hashStr)
   throw jsonrpc::JsonRpcException (-5, "unknown block hash");
 }
 
+Json::Value
+MockXayaRpcServer::decodepsbt (const std::string& psbt)
+{
+  const auto mit = psbts.find (psbt);
+  if (mit == psbts.end ())
+    throw jsonrpc::JsonRpcException (-22, "unknown psbt: " + psbt);
+  return mit->second;
+}
+
 } // namespace democrit

--- a/src/mockxaya.cpp
+++ b/src/mockxaya.cpp
@@ -1,0 +1,64 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "mockxaya.hpp"
+
+#include <jsonrpccpp/common/exception.h>
+
+#include <sstream>
+
+namespace democrit
+{
+
+int
+GetPortForMockServer ()
+{
+  static unsigned cnt = 0;
+  ++cnt;
+
+  return 2'000 + (cnt % 1'000);
+}
+
+std::string
+MockXayaRpcServer::getnewaddress ()
+{
+  ++addrCount;
+
+  std::ostringstream res;
+  res << "addr " << addrCount;
+
+  return res.str ();
+}
+
+Json::Value
+MockXayaRpcServer::name_show (const std::string& name)
+{
+  if (name == "p/invalid" || name.substr (0, 2) != "p/")
+    throw jsonrpc::JsonRpcException (-4, "name not found");
+
+  const std::string suffix = name.substr (2);
+
+  Json::Value res(Json::objectValue);
+  res["name"] = suffix;
+  res["txid"] = suffix + " txid";
+  res["vout"] = 12;
+
+  return res;
+}
+
+} // namespace democrit

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -65,6 +65,13 @@ private:
    */
   std::set<std::pair<std::string, int>> utxos;
 
+  /**
+   * Decoded JSON values to be returned for PSBTs from decodepsbt.  The keys
+   * here (the PSBT strings) are just arbitrary, and do not correspond to
+   * an actual PSBT format.
+   */
+  std::map<std::string, Json::Value> psbts;
+
   /** The current best block, e.g. returned as part of gettxout.  */
   xaya::uint256 bestBlock;
 
@@ -92,6 +99,17 @@ public:
   AddUtxo (const std::string& txid, const int vout)
   {
     utxos.emplace (txid, vout);
+  }
+
+  /**
+   * Sets the JSON value that should be returned as "decoded" form
+   * of a given PSBT.  The psbt string itself is just used as lookup key,
+   * and does not correspond to a real PSBT format.
+   */
+  void
+  SetPsbt (const std::string& psbt, const Json::Value& decoded)
+  {
+    psbts[psbt] = decoded;
   }
 
   /**
@@ -128,6 +146,13 @@ public:
    * method throws.
    */
   Json::Value getblockheader (const std::string& hashStr) override;
+
+  /**
+   * Returns the previously set JSON value (with SetPsbt) for the given
+   * psbt value (which is just used as lookup key).  If the string does not
+   * correspond to a known PSBT, throws as if it were invalid.
+   */
+  Json::Value decodepsbt (const std::string& psbt) override;
 
 };
 

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -1,0 +1,127 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEMOCRIT_MOCKXAYA_HPP
+#define DEMOCRIT_MOCKXAYA_HPP
+
+#include "private/rpcclient.hpp"
+#include "rpc-stubs/xayarpcclient.h"
+#include "rpc-stubs/xayarpcserverstub.h"
+
+#include <json/json.h>
+#include <jsonrpccpp/server.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <gmock/gmock.h>
+
+#include <string>
+
+namespace democrit
+{
+
+/**
+ * Utility method for generating server ports to be used.  It uses an
+ * internal call counter to cycle through some range, which should be good
+ * enough to find free ports even if more than one mock server are running
+ * at the same time.
+ */
+int GetPortForMockServer ();
+
+/**
+ * Mock Xaya RPC server.  It implements the RPC methods needed to process
+ * Democrit trades, but uses hard-coded data or simple fake logic for most
+ * of the things.
+ */
+class MockXayaRpcServer : public XayaRpcServerStub
+{
+
+private:
+
+  /** How many addresses have been created already.  */
+  unsigned addrCount = 0;
+
+public:
+
+  explicit MockXayaRpcServer (jsonrpc::AbstractServerConnector& conn)
+    : XayaRpcServerStub(conn)
+  {}
+
+  /**
+   * The addresses returned are of the form "addr N", which N counting
+   * how many have been created already.
+   */
+  std::string getnewaddress () override;
+
+  /**
+   * The name "p/invalid" is assumed to not exist and will throw.  For other
+   * names starting with "p/", e.g. "p/nm", the method will return the outpoint
+   * "nm txid:12" with the name filled into the txhash.
+   */
+  Json::Value name_show (const std::string& name) override;
+
+};
+
+/**
+ * Test environment with a mock Xaya RPC server (that can be parametrised
+ * using the template parameter).  It starts a real HTTP server with the
+ * mock RPC as backend, and sets up an RPC client that tests can use.
+ */
+template <typename XayaServer>
+  class TestEnvironment
+{
+
+private:
+
+  /** Port for the Xaya RPC server.  */
+  const int xayaPort;
+
+  /** HTTP server used for the test.  */
+  jsonrpc::HttpServer xayaHttpServer;
+
+  /** The Xaya RPC server.  */
+  XayaServer xayaRpcServer;
+
+  /** The RPC client connected to our mock Xaya server.  */
+  RpcClient<XayaRpcClient> xayaClient;
+
+  /**
+   * Returns the HTTP endpoint for the Xaya test server at the given port.
+   */
+  static std::string GetXayaEndpoint (int port);
+
+public:
+
+  TestEnvironment ();
+  ~TestEnvironment ();
+
+  /**
+   * Exposes the Xaya RPC client for tests.
+   */
+  RpcClient<XayaRpcClient>&
+  GetXayaRpc ()
+  {
+    return xayaClient;
+  }
+
+};
+
+} // namespace democrit
+
+#include "mockxaya.tpp"
+
+#endif // DEMOCRIT_MOCKXAYA_HPP

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -384,6 +384,15 @@ public:
   }
 
   /**
+   * Returns the endpoint of the Xaya RPC server.
+   */
+  std::string
+  GetXayaEndpoint () const
+  {
+    return GetEndpoint (xayaPort);
+  }
+
+  /**
    * Exposes the mock g/dem GSP server for controlling it.
    */
   MockDemGsp&
@@ -399,6 +408,15 @@ public:
   GetGspRpc ()
   {
     return gspClient;
+  }
+
+  /**
+   * Returns the endpoint of the g/dem GSP RPC.
+   */
+  std::string
+  GetGspEndpoint () const
+  {
+    return GetEndpoint (gspPort);
   }
 
   /**

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -142,6 +142,18 @@ public:
                                     Amount total, const std::string& move);
 
   /**
+   * Sets up the expectations for a call to walletprocesspsbt with the
+   * given input PSBT, returning a defined PSBT identifier for the "signed"
+   * transaction.  This also sets up a decoded form for the "signed" PSBT, which
+   * marks all inputs matching the input txids given as signed.  The call to
+   * walletprocesspsbt will return "complete" if all inputs are marked
+   * as signed afterwards (based on this and previous calls to SetSignedPsbt).
+   */
+  void SetSignedPsbt (const std::string& signedPsbt,
+                      const std::string& psbt,
+                      const std::set<std::string>& signTxids);
+
+  /**
    * Returns the block hash that the mock server "has" at some height
    * (e.g. with getblockheader and its prev hashes).
    */
@@ -218,6 +230,7 @@ public:
                              const std::string& name,
                              const std::string& value));
   MOCK_METHOD1 (joinpsbts, std::string (const Json::Value& psbts));
+  MOCK_METHOD1 (walletprocesspsbt, Json::Value (const std::string& psbt));
 
 };
 

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -77,6 +77,9 @@ private:
    */
   std::map<std::string, Json::Value> psbts;
 
+  /** Locked outputs in the wallet.  */
+  std::set<std::pair<std::string, unsigned>> locked;
+
   /** The current best block, e.g. returned as part of gettxout.  */
   xaya::uint256 bestBlock;
 
@@ -217,6 +220,19 @@ public:
    */
   Json::Value namepsbt (const std::string& psbt, int vout,
                         const Json::Value& nameOp) override;
+
+  /**
+   * Locks or unlocks a given output.  We mimick Xaya Core's behaviour with
+   * an "almost real" implementation of in-memory locked lists.  Returns true
+   * on success, and throws a JSON-RPC error on error (e.g. the output is
+   * already / not locked).
+   */
+  bool lockunspent (bool unlock, const Json::Value& outputs) override;
+
+  /**
+   * Returns the current list of in-memory locked outputs.
+   */
+  Json::Value listlockunspent () override;
 
   /**
    * Combines signatures in the given PSBTs.  It expects that we have a decoded

--- a/src/mockxaya.hpp
+++ b/src/mockxaya.hpp
@@ -216,6 +216,24 @@ public:
   Json::Value namepsbt (const std::string& psbt, int vout,
                         const Json::Value& nameOp) override;
 
+  /**
+   * Combines signatures in the given PSBTs.  It expects that we have a decoded
+   * form for all of them; based on that, it will produce a combined
+   * decoded JSON (putting together "signatures" as per SetSignedPsbt)
+   * and store it as the decoded form of "psbt 1 + psbt 2 + ..." for inputs
+   * "psbt 1", "psbt 2" and so on.
+   */
+  std::string combinepsbt (const Json::Value& inputPsbts) override;
+
+  /**
+   * Tries to finalise a PSBT.  It assumes that we know the decoded form
+   * of it.  The method then checks if all "inputs" have "signed":true set;
+   * if so, it returns a fake "complete" result with the "hex" field
+   * set to "rawtx <psbt>".  If not, then it returns "complete":false
+   * and the input PSBT.
+   */
+  Json::Value finalizepsbt (const std::string& psbt) override;
+
   /* The following methods are just mocked using gmock and should be used
      with explicit call expectations.  */
   MOCK_METHOD3 (CreateFundedPsbt,
@@ -231,6 +249,7 @@ public:
                              const std::string& value));
   MOCK_METHOD1 (joinpsbts, std::string (const Json::Value& psbts));
   MOCK_METHOD1 (walletprocesspsbt, Json::Value (const std::string& psbt));
+  MOCK_METHOD1 (sendrawtransaction, std::string (const std::string& hex));
 
 };
 

--- a/src/mockxaya.tpp
+++ b/src/mockxaya.tpp
@@ -27,9 +27,9 @@ template <typename XayaServer>
   TestEnvironment<XayaServer>::TestEnvironment ()
   : xayaPort(GetPortForMockServer ()), gspPort(GetPortForMockServer ()),
     xayaHttpServer(xayaPort), xayaRpcServer(xayaHttpServer),
-    xayaClient(GetEndpoint (xayaPort)),
+    xayaClient(GetXayaEndpoint ()),
     gspHttpServer(gspPort), gspRpcServer(gspHttpServer),
-    gspClient(GetEndpoint (gspPort))
+    gspClient(GetGspEndpoint ())
 {
   xayaRpcServer.StartListening ();
   gspRpcServer.StartListening ();

--- a/src/mockxaya.tpp
+++ b/src/mockxaya.tpp
@@ -1,0 +1,50 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/* Template implementation code for mockxaya.hpp.  */
+
+#include <sstream>
+
+namespace democrit
+{
+
+template <typename XayaServer>
+  TestEnvironment<XayaServer>::TestEnvironment ()
+  : xayaPort(GetPortForMockServer ()),
+    xayaHttpServer(xayaPort), xayaRpcServer(xayaHttpServer),
+    xayaClient(GetXayaEndpoint (xayaPort))
+{
+  xayaRpcServer.StartListening ();
+}
+
+template <typename XayaServer>
+  TestEnvironment<XayaServer>::~TestEnvironment ()
+{
+  xayaRpcServer.StopListening ();
+}
+
+template <typename XayaServer>
+  std::string
+  TestEnvironment<XayaServer>::GetXayaEndpoint (const int port)
+{
+  std::ostringstream res;
+  res << "http://localhost:" << port;
+  return res.str ();
+}
+
+} // namespace democrit

--- a/src/mockxaya.tpp
+++ b/src/mockxaya.tpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,22 +25,26 @@ namespace democrit
 
 template <typename XayaServer>
   TestEnvironment<XayaServer>::TestEnvironment ()
-  : xayaPort(GetPortForMockServer ()),
+  : xayaPort(GetPortForMockServer ()), gspPort(GetPortForMockServer ()),
     xayaHttpServer(xayaPort), xayaRpcServer(xayaHttpServer),
-    xayaClient(GetXayaEndpoint (xayaPort))
+    xayaClient(GetEndpoint (xayaPort)),
+    gspHttpServer(gspPort), gspRpcServer(gspHttpServer),
+    gspClient(GetEndpoint (gspPort))
 {
   xayaRpcServer.StartListening ();
+  gspRpcServer.StartListening ();
 }
 
 template <typename XayaServer>
   TestEnvironment<XayaServer>::~TestEnvironment ()
 {
   xayaRpcServer.StopListening ();
+  gspRpcServer.StopListening ();
 }
 
 template <typename XayaServer>
   std::string
-  TestEnvironment<XayaServer>::GetXayaEndpoint (const int port)
+  TestEnvironment<XayaServer>::GetEndpoint (const int port)
 {
   std::ostringstream res;
   res << "http://localhost:" << port;

--- a/src/private/checker.hpp
+++ b/src/private/checker.hpp
@@ -24,16 +24,24 @@
 #include "proto/trades.pb.h"
 #include "rpc-stubs/xayarpcclient.h"
 
+#include <json/json.h>
+
 #include <string>
 
 namespace democrit
 {
 
 /**
+ * Helper method to convert a JSON object with "txid" and "vout"
+ * to the outpoint proto.
+ */
+proto::OutPoint OutPointFromJson (const Json::Value& val);
+
+/**
  * Uses name_show to query for the current outpoint of a name, including
  * sanity-checking the response.
  */
-proto::OutPoint GetNameOutpoint (RpcClient<XayaRpcClient>& rpc,
+proto::OutPoint GetNameOutPoint (RpcClient<XayaRpcClient>& rpc,
                                  const std::string& account);
 
 /**

--- a/src/private/checker.hpp
+++ b/src/private/checker.hpp
@@ -103,6 +103,15 @@ public:
   bool CheckForBuyerTrade (proto::OutPoint& nameInput) const;
 
   /**
+   * Compares the "unsigned" and "signed" PSBT (from the buyer's point of view)
+   * and verifies that all inputs except one have been signed.  This in
+   * particular protects against being tricked into signing everything if the
+   * seller impersonates a name in the buyer's wallet.
+   */
+  bool CheckForBuyerSignature (const std::string& beforeStr,
+                               const std::string& afterStr) const;
+
+  /**
    * Verifies that the given PSBT matches the expectations of the seller
    * before signing:  The correct total is paid to their seller-data provided
    * address, and the name is updated with the expected value to their

--- a/src/private/checker.hpp
+++ b/src/private/checker.hpp
@@ -30,6 +30,13 @@ namespace democrit
 {
 
 /**
+ * Uses name_show to query for the current outpoint of a name, including
+ * sanity-checking the response.
+ */
+proto::OutPoint GetNameOutpoint (RpcClient<XayaRpcClient>& rpc,
+                                 const std::string& account);
+
+/**
  * Helper class that implements the verification of trades before the
  * buyer or seller signs them, i.e. the critical things that could result
  * in loss of funds if done wrong.

--- a/src/private/checker.hpp
+++ b/src/private/checker.hpp
@@ -1,0 +1,98 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEMOCRIT_CHECKER_HPP
+#define DEMOCRIT_CHECKER_HPP
+
+#include "assetspec.hpp"
+#include "private/rpcclient.hpp"
+#include "proto/trades.pb.h"
+#include "rpc-stubs/xayarpcclient.h"
+
+#include <string>
+
+namespace democrit
+{
+
+/**
+ * Helper class that implements the verification of trades before the
+ * buyer or seller signs them, i.e. the critical things that could result
+ * in loss of funds if done wrong.
+ */
+class TradeChecker
+{
+
+private:
+
+  /** Asset specification used for querying the game state.  */
+  const AssetSpec& spec;
+
+  /** Xaya RPC connection for checking the blockchain state.  */
+  RpcClient<XayaRpcClient>& xaya;
+
+  /** The buyer's account name.  */
+  const std::string buyer;
+
+  /** The seller's account name.  */
+  const std::string seller;
+
+  /** The asset being traded.  */
+  const Asset asset;
+
+  /** The units of asset being traded.  */
+  const Amount units;
+
+public:
+
+  explicit TradeChecker (const AssetSpec& as, RpcClient<XayaRpcClient>& x,
+                         const std::string& b, const std::string& s,
+                         const Asset& a, const Amount u)
+    : spec(as), xaya(x),
+      buyer(b), seller(s), asset(a), units(u)
+  {}
+
+  TradeChecker () = delete;
+  TradeChecker (const TradeChecker&) = delete;
+  void operator= (const TradeChecker&) = delete;
+
+  /**
+   * Returns the name_update value for the trade, based on the data we have,
+   * as a string.  This includes all the stuff like wrapping the move inside
+   * the game-ID, and also adding a "dem" move for tracking.
+   *
+   * Both buyer  and seller themselves call this method, and the seller
+   * verifies that the value used in the transaction literally matches the
+   * string returned here.  This side-steps potential pitfalls and attack
+   * vectors based on weird JSON serialisation.
+   */
+  std::string GetNameUpdateValue () const;
+
+  /**
+   * Checks if the given trade is valid from the buyer's point of view.  This
+   * mostly verifies that the seller actually has the assets and can send them,
+   * based on the current GSP and blockchain state.  If it returns true, then
+   * the seller's exact name output at which we verified is returned, and is the
+   * one that should be used as input into the trading transaction.
+   */
+  bool CheckForBuyerTrade (proto::OutPoint& nameInput) const;
+
+};
+
+} // namespace democrit
+
+#endif // DEMOCRIT_CHECKER_HPP

--- a/src/private/checker.hpp
+++ b/src/private/checker.hpp
@@ -111,6 +111,14 @@ public:
   bool CheckForSellerOutputs (const std::string& psbt,
                               const proto::SellerData& sd) const;
 
+  /**
+   * Compares the "unsigned" and "signed" PSBT (from the seller's point of view)
+   * and verifies that only the seller's name input has actually been signed.
+   */
+  bool CheckForSellerSignature (const std::string& beforeStr,
+                                const std::string& afterStr,
+                                const proto::SellerData& sd) const;
+
 };
 
 } // namespace democrit

--- a/src/private/myorders.hpp
+++ b/src/private/myorders.hpp
@@ -81,7 +81,8 @@ protected:
    * to broadcast them via XMPP, but can be used directly in tests as
    * well.
    */
-  virtual void UpdateOrders (const proto::OrdersOfAccount& ownOrders) = 0;
+  virtual void UpdateOrders (const proto::OrdersOfAccount& ownOrders)
+  {}
 
 public:
 

--- a/src/private/rpcclient.hpp
+++ b/src/private/rpcclient.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #ifndef DEMOCRIT_RPCCLIENT_HPP
 #define DEMOCRIT_RPCCLIENT_HPP
 
+#include <jsonrpccpp/client.h>
 #include <jsonrpccpp/client/connectors/httpclient.h>
 
 #include <map>
@@ -43,6 +44,9 @@ private:
   /** The JSON-RPC HTTP endpoint to use.  */
   const std::string endpoint;
 
+  /** The JSON-RPC client version to use.  */
+  const jsonrpc::clientVersion_t clientVersion;
+
   /** The HTTP client instances we use for our JSON-RPC clients per thread.  */
   std::map<std::thread::id, jsonrpc::HttpClient> httpClients;
 
@@ -54,8 +58,14 @@ private:
 
 public:
 
-  explicit RpcClient (const std::string& ep)
-    : endpoint(ep)
+  /**
+   * Constructs a new RPC client with the given endpoint.  By default it will
+   * be using the JSONRPC_CLIENT_V2 protocol; if legacy is set to true, it
+   * will use V1 instead (needed for Xaya Core).
+   */
+  explicit RpcClient (const std::string& ep, const bool l = false)
+    : endpoint(ep),
+      clientVersion(l ? jsonrpc::JSONRPC_CLIENT_V1 : jsonrpc::JSONRPC_CLIENT_V2)
   {}
 
   RpcClient () = delete;

--- a/src/private/rpcclient.tpp
+++ b/src/private/rpcclient.tpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -33,7 +33,10 @@ template <typename T>
     return mit->second;
 
   const auto http = httpClients.emplace (id, endpoint);
-  const auto rpc = rpcClients.emplace (id, http.first->second);
+  const auto rpc = rpcClients.emplace (
+      std::piecewise_construct,
+      std::forward_as_tuple (id),
+      std::forward_as_tuple (http.first->second, clientVersion));
 
   return rpc.first->second;
 }

--- a/src/private/stanzas.hpp
+++ b/src/private/stanzas.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 #define DEMOCRIT_STANZAS_HPP
 
 #include "proto/orders.pb.h"
+#include "proto/processing.pb.h"
 
 #include <gloox/stanzaextension.h>
 #include <gloox/tag.h>
@@ -102,6 +103,22 @@ class AccountOrdersStanza
 public:
 
   static constexpr const char* TAG = "orders";
+
+  using ProtoStanza::ProtoStanza;
+
+};
+
+/**
+ * Stanza for encoding a processing message, which contains the data exchanged
+ * privately between accounts while negotiating a trade.
+ */
+class ProcessingMessageStanza
+    : public ProtoStanza<proto::ProcessingMessage, 2, ProcessingMessageStanza>
+{
+
+public:
+
+  static constexpr const char* TAG = "procmsg";
 
   using ProtoStanza::ProtoStanza;
 

--- a/src/private/trades.hpp
+++ b/src/private/trades.hpp
@@ -227,6 +227,19 @@ public:
    */
   void Update ();
 
+  /**
+   * Does processing on external state (like wallet locks or myorders)
+   * for a trade that has been marked success.  This is called by TradeManager
+   * without the global state lock.
+   */
+  void HandleSuccess () const;
+
+  /**
+   * Does processing on external state for a trade that failed or got
+   * abandoned, similarly to HandleSuccess.
+   */
+  void HandleFailure () const;
+
 };
 
 /**

--- a/src/private/trades.hpp
+++ b/src/private/trades.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@
 #include "proto/orders.pb.h"
 #include "proto/processing.pb.h"
 #include "proto/trades.pb.h"
+#include "rpc-stubs/demgsprpcclient.h"
 #include "rpc-stubs/xayarpcclient.h"
 
 #include <chrono>
@@ -255,6 +256,9 @@ private:
    */
   RpcClient<XayaRpcClient>& xayaRpc;
 
+  /** RPC client for the g/dem GSP.  */
+  RpcClient<DemGspRpcClient>& demGsp;
+
   /** The periodic job running trade updates.  */
   std::unique_ptr<IntervalJob> updater;
 
@@ -306,8 +310,9 @@ public:
    * based on the timeout.  Unit tests disable updates and instead run them
    * manually as needed.
    */
-  explicit TradeManager (State& s, MyOrders& mo,
-                         const AssetSpec& as, RpcClient<XayaRpcClient>& x,
+  explicit TradeManager (State& s, MyOrders& mo, const AssetSpec& as,
+                         RpcClient<XayaRpcClient>& x,
+                         RpcClient<DemGspRpcClient>& d,
                          bool startUpdates);
 
   virtual ~TradeManager () = default;

--- a/src/private/trades.hpp
+++ b/src/private/trades.hpp
@@ -151,6 +151,12 @@ private:
   void MergeSellerData (const proto::SellerData& sd);
 
   /**
+   * Receives the counterparty's PSBT and stores it into our trade data
+   * (if we do not yet have it).
+   */
+  void MergePsbt (const proto::TradePsbt& psbt);
+
+  /**
    * Checks if we are the seller and still need to get our addresses for
    * the seller data.  If that is the case, retrieves them and adds them to
    * our TradeState proto.

--- a/src/private/trades.hpp
+++ b/src/private/trades.hpp
@@ -154,6 +154,13 @@ private:
   /** The global state we use to read our trades from.  */
   State& state;
 
+  /**
+   * Process all active trades and move those that are finalised to the
+   * trade archive instead.
+   */
+  void ArchiveFinalisedTrades ();
+
+  friend class TestTradeManager;
   friend class Trade;
 
 protected:

--- a/src/private/trades.hpp
+++ b/src/private/trades.hpp
@@ -1,0 +1,202 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEMOCRIT_TRADES_HPP
+#define DEMOCRIT_TRADES_HPP
+
+#include "assetspec.hpp"
+#include "private/state.hpp"
+#include "proto/orders.pb.h"
+#include "proto/trades.pb.h"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace democrit
+{
+
+class TestTradeManager;
+class TradeManager;
+
+/**
+ * Wrapper class around a TradeState protocol buffer, which has logic
+ * to extract some data from the raw proto (e.g. our role in the trade)
+ * as well as perform updates based on new data from the counterparty.
+ *
+ * Instances of this class are used purely temporarily, to work with
+ * the underlying protocol buffers from the global state.
+ */
+class Trade
+{
+
+private:
+
+  /**
+   * The chrono clock used for the trade start time and for checking the
+   * time it is active and (perhaps) timing it out.  Since C++20,
+   * std::system_time is guaranteed to have an epoch based on the UNIX epoch;
+   * even before that, that is the de-facto standard.
+   */
+  using Clock = std::chrono::system_clock;
+
+  /**
+   * The trade manager instance we are using, which holds general stuff like
+   * RPC connections.
+   */
+  const TradeManager& tm;
+
+  /** The current user's account name.  */
+  const std::string& account;
+
+  /**
+   * The actual data for this.  This references the instance inside the
+   * global state, and the global state will be locked during the entire
+   * time of using this instance.
+   */
+  proto::TradeState& pb;
+
+  /**
+   * True if pb is mutable (i.e. the instance is constructed from a non-const
+   * proto::TradeState& reference).
+   */
+  const bool isMutable;
+
+  explicit Trade (const TradeManager& t, const std::string& a,
+                  const proto::TradeState& p)
+    : tm(t), account(a),
+      pb(const_cast<proto::TradeState&> (p)), isMutable(false)
+  {}
+
+  explicit Trade (const TradeManager& t, const std::string& a,
+                  proto::TradeState& p)
+    : tm(t), account(a),
+      pb(p), isMutable(true)
+  {}
+
+  /**
+   * Returns an ID that is used to identify the particular trade among
+   * all active trades, e.g. when matching up with received messages.
+   * This consists of the maker's account name and the maker's order ID.
+   * Both maker and taker, if working correctly, will make sure that no two
+   * trades will be active at the same time for the same order ID.
+   */
+  std::string GetIdentifier () const;
+
+  /**
+   * Returns the type of order this is from our point of view.  In other words,
+   * ASK if we are selling, and BID if we are buying.
+   */
+  proto::Order::Type GetOrderType () const;
+
+  /**
+   * Returns the role we have in this trade (maker or taker).
+   */
+  proto::Trade::Role GetRole () const;
+
+  /**
+   * Returns the chrono time-point corresponding to the proto data.
+   */
+  Clock::time_point GetStartTime () const;
+
+  friend class TestTradeManager;
+  friend class TradeManager;
+
+public:
+
+  Trade () = delete;
+  Trade (const Trade&) = delete;
+  void operator= (const Trade&) = delete;
+
+  /**
+   * Returns true if the trade is finalised.  This means that it is either
+   * abandoned or we have seen sufficient confirmations on either the trade
+   * itself or a double spend to consider it "done".  When this returns true,
+   * a trade may be archived.
+   */
+  bool IsFinalised () const;
+
+  /**
+   * Returns data of this trade in the Trade proto format, which is used
+   * in the public, external interface of Democrit.
+   */
+  proto::Trade GetPublicInfo () const;
+
+};
+
+/**
+ * This class is responsible for managing the list of trades of the current
+ * user account.  It holds some general stuff needed for processing trades,
+ * and takes care of constructing the Trade instances as needed to handle
+ * certain operations (like extracting the public data for all trades
+ * or updating them for incoming messages).
+ */
+class TradeManager
+{
+
+private:
+
+  /** The global state we use to read our trades from.  */
+  State& state;
+
+  friend class Trade;
+
+protected:
+
+  /**
+   * Returns the current time (based on Trade::Clock) as UNIX timestamp,
+   * which is stored in the TradeState proto.  For testing this is mocked
+   * to return a fake time instead.
+   */
+  virtual int64_t GetCurrentTime () const;
+
+public:
+
+  explicit TradeManager (State& s)
+    : state(s)
+  {}
+
+  virtual ~TradeManager () = default;
+
+  TradeManager () = delete;
+  TradeManager (const TradeManager&) = delete;
+  void operator= (const TradeManager&) = delete;
+
+  /**
+   * Returns the public data about all trades in our state.
+   */
+  std::vector<proto::Trade> GetTrades () const;
+
+  /**
+   * Adds a new trade, based on taking the given order (i.e. we are the
+   * taker, and the order is from the counterparty).  Returns true on success.
+   */
+  bool TakeOrder (const proto::Order& o, const Amount units);
+
+  /**
+   * Adds a new trade, based on one of our own orders being taken by
+   * some counterparty.
+   */
+  bool OrderTaken (const proto::Order& o, const Amount units,
+                   const std::string& taker);
+
+};
+
+} // namespace democrit
+
+#endif // DEMOCRIT_TRADES_HPP

--- a/src/proto/processing.proto
+++ b/src/proto/processing.proto
@@ -42,6 +42,18 @@ message TakingOrder
 }
 
 /**
+ * Message telling the counterparty about the constructed PSBT or an update
+ * to the existing PSBT with our signatures.
+ */
+message TradePsbt
+{
+
+  /** The new or updated PSBT in base64 form.  */
+  optional string psbt = 1;
+
+}
+
+/**
  * A message sent via XMPP direct messages between the two parties finalising
  * a trade between them.
  */
@@ -76,5 +88,8 @@ message ProcessingMessage
 
   /** The seller telling the buyer their addresses.  */
   optional SellerData seller_data = 102;
+
+  /** A new or updated PSBT for the trade.  */
+  optional TradePsbt psbt = 103;
 
 }

--- a/src/proto/processing.proto
+++ b/src/proto/processing.proto
@@ -1,0 +1,80 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+
+import "trades.proto";
+
+package democrit.proto;
+
+/**
+ * Message telling another party that we want to take one of their orders.
+ */
+message TakingOrder
+{
+
+  /**
+   * The ID of the maker's order being taken.  This is in theory redundant
+   * with the "identifier" string being present in ProcessingMessage itself,
+   * but is included here anyway so the identifier string can be seen as
+   * something more abstract.
+   */
+  optional uint64 id = 1;
+
+  /** The exact number of units we want to take.  */
+  optional uint64 units = 2;
+
+}
+
+/**
+ * A message sent via XMPP direct messages between the two parties finalising
+ * a trade between them.
+ */
+message ProcessingMessage
+{
+
+  /**
+   * The counterparty this message is for (as Xaya name).  This is set in the
+   * proto internally, but cleared when the message is actually attached
+   * as XMPP stanza (as the recipient is explicit in the XMPP message anyway).
+   */
+  optional string counterparty = 1;
+
+  /**
+   * The trade's internal identifier, as per Trade::GetIdentifier.
+   * This is a string consisting of the maker and order ID, which uniquely
+   * identifies this trade among all active trades of either the taker or
+   * maker, as long as they themselves behave correctly.
+   */
+  optional string identifier = 2;
+
+  /* The fields following now define the actual payload corresponding to
+     the processing steps done on the trade.  They are processed in order
+     and a message may contain more than one of them (especially when taking
+     a buy order), although typically it will hold just one.  */
+
+  /**
+   * If this is the initial message starting a trade, then this tells the
+   * counterparty that we want to take an order of theirs.
+   */
+  optional TakingOrder taking_order = 101;
+
+  /** The seller telling the buyer their addresses.  */
+  optional SellerData seller_data = 102;
+
+}

--- a/src/proto/state.proto
+++ b/src/proto/state.proto
@@ -45,7 +45,10 @@ message State
      (i.e. when restarting the Democrit process, it should be received
      again fresh rather than restored from a previous save).  */
 
-  /** The list of active / failed / succeeded trades involving us.  */
+  /** The list of active trades involving us.  */
   repeated TradeState trades = 4;
+
+  /** Archived trades (abandoned / succeeded / failed).  */
+  repeated Trade trade_archive = 5;
 
 }

--- a/src/proto/state.proto
+++ b/src/proto/state.proto
@@ -19,6 +19,7 @@
 syntax = "proto2";
 
 import "orders.proto";
+import "trades.proto";
 
 package democrit.proto;
 
@@ -43,5 +44,8 @@ message State
      timepoints with it, and it is ephemeral in nature in general anyway
      (i.e. when restarting the Democrit process, it should be received
      again fresh rather than restored from a previous save).  */
+
+  /** The list of active / failed / succeeded trades involving us.  */
+  repeated TradeState trades = 4;
 
 }

--- a/src/proto/trades.proto
+++ b/src/proto/trades.proto
@@ -236,4 +236,13 @@ message TradeState
    */
   optional string their_psbt = 8;
 
+  /**
+   * We notice that a trade has failed when one of its inputs is no longer
+   * available (but it also has not yet been marked as confirmed).  There is
+   * no easy way to check when that input was double-spent; instead, we remember
+   * the block height when we first noticed this here, so that we then know
+   * when we are enough blocks past the point.
+   */
+  optional uint64 conflict_height = 9;
+
 }

--- a/src/proto/trades.proto
+++ b/src/proto/trades.proto
@@ -1,0 +1,239 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+syntax = "proto2";
+
+import "orders.proto";
+
+package democrit.proto;
+
+/**
+ * Basic data about a trade.  This message is used in the public interface,
+ * i.e. to return to users of Democrit as a library (or the RPC interface
+ * in JSON form) what the state of a trade is.  It can be derived directly
+ * from a TradeState instance, which holds the real data as stored internally.
+ */
+message Trade
+{
+
+  /** State a trade can be in per the public interface.  */
+  enum State
+  {
+
+    /** The trade has been initiated, but we have not yet shared signatures.  */
+    INITIATED = 1;
+
+    /**
+     * We have shared our signatures with the counterparty (as the taker)
+     * or submitted the transaction to the network (as the maker).
+     */
+    PENDING = 2;
+
+    /** The trade has gone through and the transaction confirmed.  */
+    SUCCESS = 3;
+
+    /** The trade failed because an input was double spent.  */
+    FAILED = 4;
+
+    /**
+     * We have abandoned the trade.  This means that we have not yet shared
+     * our signatures with the counterparty, but have decided to stop proceeding
+     * further, e.g. because the counterparty timed out.
+     */
+    ABANDONED = 5;
+
+  }
+
+  /** The state this trade is in.  */
+  optional State state = 1;
+
+  /** The UNIX timestamp when this trade was started.  */
+  optional int64 start_time = 2;
+
+  /** The counterparty Xaya account name.  */
+  optional string counterparty = 3;
+
+  /**
+   * The type of order from our point of view.  For instance, if this is
+   * ASK, then we are selling and the counterparty is buying.
+   */
+  optional Order.Type type = 4;
+
+  /** The asset type being traded.  */
+  optional string asset = 5;
+
+  /** The number of units being traded.  */
+  optional uint64 units = 6;
+
+  /** The price per unit in CHI satoshi.  */
+  optional uint64 price_sat = 7;
+
+  /** A role that we can have in a trade.  */
+  enum Role
+  {
+
+    /** We are the maker (i.e. our order was taken by someone).  */
+    MAKER = 1;
+
+    /** We are the taker, trading against an order on the book.  */
+    TAKER = 2;
+
+  }
+
+  /** Our role in this trade.  */
+  optional Role role = 8;
+
+}
+
+/**
+ * A transaction outpoint / UTXO.
+ */
+message OutPoint
+{
+
+  /** The hash of the transaction that created the output (hex string).  */
+  optional string hash = 1;
+
+  /** The index of the output in the creating transaction's vout.  */
+  optional uint32 n = 2;
+
+}
+
+/**
+ * The data needed from the seller for constructing the transaction.
+ */
+message SellerData
+{
+
+  /** Address for sending the updated name to.  */
+  optional string name_address = 1;
+
+  /** Address for the CHI payment.  */
+  optional string chi_address = 2;
+
+  /**
+   * If we are the seller, then this contains the name output we intend
+   * to spend in the transaction (before receiving the buyer-constructed
+   * transaction) and also the one we locked for the trade in our wallet.
+   */
+  optional OutPoint name_output = 3;
+
+}
+
+/**
+ * State data that a party stores about a particular trade being negotiated
+ * or already finished (or failed).
+ */
+message TradeState
+{
+
+  /* ************************************************************************ */
+  /* Base data, which is always set from creation.  */
+
+  /**
+   * The order being taken.  This includes the main data specifying what
+   * we are expecting from the trade (e.g. the price).  It also includes
+   * the maker's account name and order ID, which can be used to identify
+   * the trade uniquely among all active trades.  (This is the case since
+   * the maker won't accept another taker until the previous trade is either
+   * abandoned or finished, and the taker also won't try to take an order
+   * twice unless they do something wrong.)
+   *
+   * Since we know our own account name and can match it with the account
+   * in the order, this field implicitly specifies what role (maker / taker)
+   * we have on this trade.
+   */
+  optional Order order = 1;
+
+  /**
+   * The amount to be traded.  This may be less than the maximum amount
+   * from order.
+   */
+  optional uint64 units = 2;
+
+  /**
+   * The counterparty's account name (used to match incoming messages
+   * and send outgoing ones).
+   */
+  optional string counterparty = 3;
+
+  /** UNIX timestamp for when the trade was started.  */
+  optional int64 start_time = 4;
+
+  /* ************************************************************************ */
+  /* Data that gets set/updated as it becomes available during processing.  */
+
+  /**
+   * The state of this trade.  This is used e.g. to know when a trade has
+   * been finalised (abandoned or confirmed success/failure).  The distinction
+   * between PENDING and INITIATED is used to determine wheter we have already
+   * provided our signatures to the counterparty / broadcast the transaction
+   * or it is still in progress of being built up.
+   */
+  optional Trade.State state = 5;
+
+  /**
+   * The seller's address data for this trade (if known already).  If we are
+   * the seller, we set this field as well once those have been sent.  This is
+   * useful to verify the buyer-constructed transaction (i.e. that it matches
+   * the data we asked for).
+   */
+  optional SellerData seller_data = 6;
+
+  /* We have two data fields that we use to keep track of the current
+     state and data while exchanging PSBTs with the counterparty.  Depending
+     on our role in the process:
+
+     - maker/buyer:  After constructing the transaction, we sign it and fill
+       in our_psbt with the partially signed transaction.  We share the
+       unsigned transaction with the counterparty to sign first.  When we
+       receive their signatures back, we fill in their_psbt and then
+       combine them and finalise the trade.
+
+     - maker/seller:  The counterparty will construct the transaction and
+       share the partially signed one right away with us.  Upon receipt,
+       we fill it into their_psbt.  Then when processing, we sign that
+       transaction, write the fully signed one into our_psbt, and
+       broadcast it.
+
+     - taker/buyer:  We construct the transaction, sign our part, and store
+       the partially signed transaction in our_psbt.  We then share this with
+       the counterparty, and wait for confirmation on the network.  their_psbt
+       is never used in this case.
+
+     - taker/seller:  The counterparty constructs the transaction and shares
+       an unsigned version with us, which we store in their_psbt.  We then
+       sign it from there, store the partially signed version into our_psbt,
+       send it back and wait for network confirmation.  */
+
+  /**
+   * The partially (or fully) signed transaction with our signatures
+   * as PSBT.  This field is always present if we have signed our part,
+   * and lets us e.g. check the transaction's inputs for double-spends
+   * as well as tells us the btxid of the trade.
+   */
+  optional string our_psbt = 7;
+
+  /**
+   * The partially signed transaction as we have received it from the
+   * counterparty, if we have received any so far.  This might be fully
+   * unsigned or have the counterparty's signatures on it already.
+   */
+  optional string their_psbt = 8;
+
+}

--- a/src/rpc-stubs/daemon.json
+++ b/src/rpc-stubs/daemon.json
@@ -43,5 +43,20 @@
         "id": 42
       },
     "returns": {}
+  },
+
+  {
+    "name": "gettrades",
+    "params": {},
+    "returns": []
+  },
+  {
+    "name": "takeorder",
+    "params":
+      {
+        "order": {},
+        "units": 42
+      },
+    "returns": true
   }
 ]

--- a/src/rpc-stubs/dem-gsp.json
+++ b/src/rpc-stubs/dem-gsp.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "checktrade",
+    "params": ["btxid"],
+    "returns": {}
+  }
+]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -46,5 +46,11 @@
     "name": "joinpsbts",
     "params": [["psbt 1", "psbt 2"]],
     "returns": "psbt"
+  },
+
+  {
+    "name": "walletprocesspsbt",
+    "params": ["psbt"],
+    "returns": {}
   }
 ]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -52,5 +52,21 @@
     "name": "walletprocesspsbt",
     "params": ["psbt"],
     "returns": {}
+  },
+
+  {
+    "name": "combinepsbt",
+    "params": [["psbts"]],
+    "returns": "psbt"
+  },
+  {
+    "name": "finalizepsbt",
+    "params": ["psbt"],
+    "returns": {}
+  },
+  {
+    "name": "sendrawtransaction",
+    "params": ["hex"],
+    "returns": "txid"
   }
 ]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "getnewaddress",
+    "params": [],
+    "returns": "foo"
+  },
+  {
+    "name": "name_show",
+    "params": ["p/domob"],
+    "returns": {}
+  }
+]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -19,5 +19,11 @@
     "name": "getblockheader",
     "params": ["hash"],
     "returns": {}
+  },
+
+  {
+    "name": "decodepsbt",
+    "params": ["psbt"],
+    "returns": {}
   }
 ]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -4,9 +4,20 @@
     "params": [],
     "returns": "foo"
   },
+
   {
     "name": "name_show",
     "params": ["p/domob"],
+    "returns": {}
+  },
+  {
+    "name": "gettxout",
+    "params": ["txid", 42],
+    "returns": {}
+  },
+  {
+    "name": "getblockheader",
+    "params": ["hash"],
     "returns": {}
   }
 ]

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -53,6 +53,16 @@
     "params": ["psbt"],
     "returns": {}
   },
+  {
+    "name": "lockunspent",
+    "params": [false, ["outputs"]],
+    "returns": true
+  },
+  {
+    "name": "listlockunspent",
+    "params": [],
+    "returns": []
+  },
 
   {
     "name": "combinepsbt",

--- a/src/rpc-stubs/xaya.json
+++ b/src/rpc-stubs/xaya.json
@@ -25,5 +25,26 @@
     "name": "decodepsbt",
     "params": ["psbt"],
     "returns": {}
+  },
+
+  {
+    "name": "walletcreatefundedpsbt",
+    "params": [["inputs"], ["outputs"], 42, {"options": true}],
+    "returns": {}
+  },
+  {
+    "name": "createpsbt",
+    "params": [["inputs"], ["outputs"]],
+    "returns": "psbt"
+  },
+  {
+    "name": "namepsbt",
+    "params": ["psbt", 42, {"op": "name_update"}],
+    "returns": {}
+  },
+  {
+    "name": "joinpsbts",
+    "params": [["psbt 1", "psbt 2"]],
+    "returns": "psbt"
   }
 ]

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -106,6 +106,29 @@ RpcServer::cancelorder (const int id)
   LOG (INFO) << "RPC method called: cancelorder " << id;
   daemon.CancelOrder (id);
   return Json::Value ();
+}
+
+Json::Value
+RpcServer::gettrades ()
+{
+  LOG (INFO) << "RPC method called: gettrades";
+  Json::Value res(Json::arrayValue);
+  for (const auto& t : daemon.GetTrades ())
+    res.append (ProtoToJson (t));
+  return res;
+}
+
+bool
+RpcServer::takeorder (const Json::Value& order, const int units)
+{
+  LOG (INFO) << "RPC method called: takeorder\n" << order << "\n" << units;
+
+  proto::Order o;
+  if (!ProtoFromJson (order, o))
+    throw jsonrpc::JsonRpcException (jsonrpc::Errors::ERROR_RPC_INVALID_PARAMS,
+                                     "invalid order");
+
+  return daemon.TakeOrder (o, units);
 }
 
 } // namespace democrit

--- a/src/rpcserver.hpp
+++ b/src/rpcserver.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -75,6 +75,9 @@ public:
   Json::Value getownorders () override;
   bool addorder (const Json::Value& order) override;
   Json::Value cancelorder (int id) override;
+
+  Json::Value gettrades () override;
+  bool takeorder (const Json::Value& order, int units) override;
 
 };
 

--- a/src/stanzas.cpp
+++ b/src/stanzas.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,5 +22,6 @@ namespace democrit
 {
 
 constexpr const char* AccountOrdersStanza::TAG;
+constexpr const char* ProcessingMessageStanza::TAG;
 
 } // namespace democrit

--- a/src/stanzas_tests.cpp
+++ b/src/stanzas_tests.cpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -86,6 +86,14 @@ TEST_F (StanzasTests, AccountOrdersStanza)
         key: 102
         value: { asset: "gold" type: ASK price_sat: 20 }
       }
+  )");
+}
+
+TEST_F (StanzasTests, ProcessingMessageStanza)
+{
+  ProtoStanzaRoundtrip<ProcessingMessageStanza> (R"(
+    identifier: "me\n42"
+    psbt: { psbt: "abc" }
   )");
 }
 

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -19,6 +19,7 @@
 #include "testutils.hpp"
 
 #include <chrono>
+#include <sstream>
 #include <thread>
 
 namespace democrit
@@ -82,6 +83,15 @@ void
 SleepSome ()
 {
   std::this_thread::sleep_for (std::chrono::milliseconds (10));
+}
+
+Json::Value
+ParseJson (const std::string& str)
+{
+  std::istringstream in(str);
+  Json::Value res;
+  in >> res;
+  return res;
 }
 
 constexpr const char* TestAssets::GAME_ID;

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -104,6 +104,11 @@ gloox::JID GetRoom (const std::string& nm);
 void SleepSome ();
 
 /**
+ * Parses a string to JSON.
+ */
+Json::Value ParseJson (const std::string& str);
+
+/**
  * Parses a protocol buffer from text format.
  */
 template <typename Proto>

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -1,6 +1,6 @@
 /*
     Democrit - atomic trades for XAYA games
-    Copyright (C) 2020  Autonomous Worlds Ltd
+    Copyright (C) 2020-2021  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 
 #include "assetspec.hpp"
 #include "proto/orders.pb.h"
+#include "proto/trades.pb.h"
 
 #include <xayautil/uint256.hpp>
 
@@ -133,6 +134,8 @@ template <typename Proto>
 DEFINE_PROTO_MATCHER (EqualsOrdersForAsset, OrderbookForAsset)
 DEFINE_PROTO_MATCHER (EqualsOrdersByAsset, OrderbookByAsset)
 DEFINE_PROTO_MATCHER (EqualsOrdersOfAccount, OrdersOfAccount)
+DEFINE_PROTO_MATCHER (EqualsTradeState, TradeState)
+DEFINE_PROTO_MATCHER (EqualsTrade, Trade)
 
 /**
  * Very simple AssetSpec to be used in testing.  It defines three valid

--- a/src/trades.cpp
+++ b/src/trades.cpp
@@ -1,0 +1,231 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/trades.hpp"
+
+#include <glog/logging.h>
+
+#include <sstream>
+
+namespace democrit
+{
+
+/* ************************************************************************** */
+
+std::string
+Trade::GetIdentifier () const
+{
+  /* New lines are not valid inside Xaya names, so they can act as
+     separator between maker name and order ID.  */
+
+  std::ostringstream res;
+  res << pb.order ().account () << '\n' << pb.order ().id ();
+
+  return res.str ();
+}
+
+proto::Order::Type
+Trade::GetOrderType () const
+{
+  const auto role = GetRole ();
+  if (role == proto::Trade::MAKER)
+    return pb.order ().type ();
+  CHECK_EQ (role, proto::Trade::TAKER) << "Unexpected role: " << role;
+
+  switch (pb.order ().type ())
+    {
+    case proto::Order::BID:
+      return proto::Order::ASK;
+    case proto::Order::ASK:
+      return proto::Order::BID;
+    default:
+      LOG (FATAL) << "Unexpected order type: " << pb.order ().type ();
+    }
+}
+
+proto::Trade::Role
+Trade::GetRole () const
+{
+  return pb.order ().account () == account
+      ? proto::Trade::MAKER
+      : proto::Trade::TAKER;
+}
+
+Trade::Clock::time_point
+Trade::GetStartTime () const
+{
+  return Clock::time_point (std::chrono::seconds (pb.start_time ()));
+}
+
+bool
+Trade::IsFinalised () const
+{
+  if (!pb.has_state ())
+    return false;
+
+  switch (pb.state ())
+    {
+    case proto::Trade::ABANDONED:
+    case proto::Trade::SUCCESS:
+    case proto::Trade::FAILED:
+      return true;
+
+    default:
+      return false;
+    }
+}
+
+proto::Trade
+Trade::GetPublicInfo () const
+{
+  proto::Trade res;
+  res.set_state (pb.state ());
+  res.set_start_time (pb.start_time ());
+  res.set_counterparty (pb.counterparty ());
+  res.set_type (GetOrderType ());
+  res.set_asset (pb.order ().asset ());
+  res.set_units (pb.units ());
+  res.set_price_sat (pb.order ().price_sat ());
+  res.set_role (GetRole ());
+  return res;
+}
+
+/* ************************************************************************** */
+
+std::vector<proto::Trade>
+TradeManager::GetTrades () const
+{
+  std::vector<proto::Trade> res;
+  state.ReadState ([this, &res] (const proto::State& s)
+    {
+      for (const auto& t : s.trades ())
+        res.push_back (Trade (*this, s.account (), t).GetPublicInfo ());
+    });
+
+  return res;
+}
+
+int64_t
+TradeManager::GetCurrentTime () const
+{
+  const auto dur = Trade::Clock::now ().time_since_epoch ();
+  return std::chrono::duration_cast<std::chrono::seconds> (dur).count ();
+}
+
+namespace
+{
+
+/**
+ * Checks if the given order can be taken with the given amount,
+ * and that it has in general all the fields necessary and is valid
+ * for our purposes (so we can start a trade).
+ */
+bool
+CheckOrder (const proto::Order& o, const Amount units)
+{
+  if (units > static_cast<Amount> (o.max_units ())
+        || units < static_cast<Amount> (o.min_units ()))
+    {
+      LOG (WARNING)
+          << "Cannot take order for " << units << " units:\n"
+          << o.DebugString ();
+      return false;
+    }
+
+  if (!o.has_account () || !o.has_id ()
+        || !o.has_asset () || !o.has_type () || !o.has_price_sat ())
+    {
+      LOG (WARNING) << "Order to take is missing fields:\n" << o.DebugString ();
+      return false;
+    }
+
+  return true;
+}
+
+} // anonymous namespace
+
+bool
+TradeManager::TakeOrder (const proto::Order& o, const Amount units)
+{
+  if (!CheckOrder (o, units))
+    return false;
+
+  proto::TradeState data;
+  *data.mutable_order () = o;
+  data.set_start_time (GetCurrentTime ());
+  data.set_units (units);
+  data.set_counterparty (o.account ());
+  data.set_state (proto::Trade::INITIATED);
+
+  bool ok;
+  state.AccessState ([&data, &ok] (proto::State& s)
+    {
+      if (data.counterparty () == s.account ())
+        {
+          LOG (WARNING)
+              << "Can't take own order:\n" << data.order ().DebugString ();
+          ok = false;
+        }
+      else
+        {
+          *s.mutable_trades ()->Add () = std::move (data);
+          ok = true;
+        }
+    });
+
+  return ok;
+}
+
+bool
+TradeManager::OrderTaken (const proto::Order& o, const Amount units,
+                          const std::string& counterparty)
+{
+  if (!CheckOrder (o, units))
+    return false;
+
+  proto::TradeState data;
+  *data.mutable_order () = o;
+  data.set_start_time (GetCurrentTime ());
+  data.set_units (units);
+  data.set_counterparty (counterparty);
+  data.set_state (proto::Trade::INITIATED);
+
+  bool ok;
+  state.AccessState ([&data, &ok] (proto::State& s)
+    {
+      CHECK_EQ (data.order ().account (), s.account ());
+
+      if (data.counterparty () == s.account ())
+        {
+          LOG (WARNING)
+              << "Order taken by ourselves:\n" << data.order ().DebugString ();
+          ok = false;
+        }
+      else
+        {
+          *s.mutable_trades ()->Add () = std::move (data);
+          ok = true;
+        }
+    });
+
+  return ok;
+}
+
+/* ************************************************************************** */
+
+} // namespace democrit

--- a/src/trades_tests.cpp
+++ b/src/trades_tests.cpp
@@ -1,0 +1,357 @@
+/*
+    Democrit - atomic trades for XAYA games
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/trades.hpp"
+
+#include "private/state.hpp"
+#include "testutils.hpp"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace democrit
+{
+
+namespace
+{
+
+using testing::ElementsAre;
+
+DEFINE_PROTO_MATCHER (EqualsTradeState, TradeState)
+DEFINE_PROTO_MATCHER (EqualsTrade, Trade)
+
+} // anonymous namespace
+
+/* ************************************************************************** */
+
+/**
+ * TradeManager instance used in tests.  It holds a State instance and
+ * some fake data / mock RPC connections.  "me" is the account name
+ * used for the current user.
+ */
+class TestTradeManager : public State, public TradeManager
+{
+
+private:
+
+  /** The mock time to return as "current" for created trades.  */
+  int64_t mockTime;
+
+  int64_t
+  GetCurrentTime () const override
+  {
+    return mockTime;
+  }
+
+public:
+
+  TestTradeManager ()
+    : State("me"), TradeManager(static_cast<State&> (*this)),
+      mockTime(0)
+  {}
+
+  void
+  SetMockTime (const int64_t t)
+  {
+    mockTime = t;
+  }
+
+  /**
+   * Constructs a new Trade instance, based on the given data parsed
+   * as text-format TradeState.
+   */
+  std::unique_ptr<Trade>
+  GetTrade (const std::string& data)
+  {
+    auto pb = ParseTextProto<proto::TradeState> (data);
+    proto::TradeState* ref;
+    AccessState ([&pb, &ref] (proto::State& s)
+      {
+        s.clear_trades ();
+        ref = s.mutable_trades ()->Add ();
+        *ref = std::move (pb);
+      });
+
+    static const std::string me = "me";
+    return std::unique_ptr<Trade> (new Trade (*this, me, *ref));
+  }
+
+};
+
+namespace
+{
+
+/* ************************************************************************** */
+
+class TradeStateTests : public testing::Test
+{
+
+protected:
+
+  TestTradeManager tm;
+
+  /**
+   * Returns the public info data (Trade::GetPublicInfo) for the given
+   * TradeState from text proto.
+   */
+  proto::Trade
+  GetPublicInfo (const std::string& data)
+  {
+    return tm.GetTrade (data)->GetPublicInfo ();
+  }
+
+};
+
+TEST_F (TradeStateTests, MakerBuyer)
+{
+  EXPECT_THAT (GetPublicInfo (R"(
+    state: INITIATED
+    start_time: 123
+    order:
+      {
+        account: "me"
+        asset: "gold"
+        price_sat: 100
+        type: BID
+      }
+    units: 42
+    counterparty: "other"
+  )"), EqualsTrade (R"(
+    state: INITIATED
+    start_time: 123
+    counterparty: "other"
+    role: MAKER
+    type: BID
+    asset: "gold"
+    units: 42
+    price_sat: 100
+  )"));
+}
+
+TEST_F (TradeStateTests, MakerSeller)
+{
+  EXPECT_THAT (GetPublicInfo (R"(
+    state: INITIATED
+    start_time: 123
+    order:
+      {
+        account: "me"
+        asset: "gold"
+        price_sat: 100
+        type: ASK
+      }
+    units: 42
+    counterparty: "other"
+  )"), EqualsTrade (R"(
+    state: INITIATED
+    start_time: 123
+    counterparty: "other"
+    role: MAKER
+    type: ASK
+    asset: "gold"
+    units: 42
+    price_sat: 100
+  )"));
+}
+
+TEST_F (TradeStateTests, TakerBuyer)
+{
+  EXPECT_THAT (GetPublicInfo (R"(
+    state: INITIATED
+    start_time: 123
+    order:
+      {
+        account: "other"
+        asset: "gold"
+        price_sat: 100
+        type: ASK
+      }
+    units: 42
+    counterparty: "other"
+  )"), EqualsTrade (R"(
+    state: INITIATED
+    start_time: 123
+    counterparty: "other"
+    role: TAKER
+    type: BID
+    asset: "gold"
+    units: 42
+    price_sat: 100
+  )"));
+}
+
+TEST_F (TradeStateTests, TakerSeller)
+{
+  EXPECT_THAT (GetPublicInfo (R"(
+    state: INITIATED
+    start_time: 123
+    order:
+      {
+        account: "other"
+        asset: "gold"
+        price_sat: 100
+        type: BID
+      }
+    units: 42
+    counterparty: "other"
+  )"), EqualsTrade (R"(
+    state: INITIATED
+    start_time: 123
+    counterparty: "other"
+    role: TAKER
+    type: ASK
+    asset: "gold"
+    units: 42
+    price_sat: 100
+  )"));
+}
+
+TEST_F (TradeStateTests, IsFinalised)
+{
+  EXPECT_TRUE (tm.GetTrade (R"(
+    state: ABANDONED
+  )")->IsFinalised ());
+  EXPECT_TRUE (tm.GetTrade (R"(
+    state: SUCCESS
+  )")->IsFinalised ());
+  EXPECT_TRUE (tm.GetTrade (R"(
+    state: FAILED
+  )")->IsFinalised ());
+}
+
+/* ************************************************************************** */
+
+class TradeManagerTests : public testing::Test
+{
+
+protected:
+
+  TestTradeManager tm;
+
+  TradeManagerTests ()
+  {
+    tm.SetMockTime (123);
+  }
+
+};
+
+TEST_F (TradeManagerTests, OrderVerification)
+{
+  const auto o = ParseTextProto<proto::Order> (R"(
+    account: "other"
+    id: 42
+    asset: "gold"
+    min_units: 10
+    max_units: 100
+    price_sat: 42
+    type: BID
+  )");
+
+  EXPECT_FALSE (tm.TakeOrder (o, 9));
+  EXPECT_FALSE (tm.TakeOrder (o, 101));
+
+  auto modified = o;
+  modified.clear_account ();
+  EXPECT_FALSE (tm.TakeOrder (modified, 10));
+
+  modified = o;
+  modified.clear_id ();
+  EXPECT_FALSE (tm.TakeOrder (modified, 10));
+
+  modified = o;
+  modified.clear_asset ();
+  EXPECT_FALSE (tm.TakeOrder (modified, 10));
+
+  modified = o;
+  modified.clear_price_sat ();
+  EXPECT_FALSE (tm.TakeOrder (modified, 10));
+
+  modified = o;
+  modified.clear_type ();
+  EXPECT_FALSE (tm.TakeOrder (modified, 10));
+
+  EXPECT_THAT (tm.GetTrades (), ElementsAre ());
+}
+
+TEST_F (TradeManagerTests, TakingOwnOrder)
+{
+  const auto o = ParseTextProto<proto::Order> (R"(
+    account: "me"
+    id: 42
+    asset: "gold"
+    max_units: 100
+    price_sat: 42
+    type: BID
+  )");
+
+  EXPECT_FALSE (tm.TakeOrder (o, 10));
+  EXPECT_FALSE (tm.OrderTaken (o, 10, "me"));
+
+  EXPECT_THAT (tm.GetTrades (), ElementsAre ());
+}
+
+TEST_F (TradeManagerTests, TakingOrderSuccess)
+{
+  const auto own = ParseTextProto<proto::Order> (R"(
+    account: "me"
+    id: 42
+    asset: "gold"
+    max_units: 100
+    price_sat: 42
+    type: BID
+  )");
+  const auto other = ParseTextProto<proto::Order> (R"(
+    account: "other"
+    id: 42
+    asset: "gold"
+    max_units: 100
+    price_sat: 64
+    type: ASK
+  )");
+
+  ASSERT_TRUE (tm.OrderTaken (own, 100, "other"));
+  ASSERT_TRUE (tm.TakeOrder (other, 10));
+
+  EXPECT_THAT (tm.GetTrades (), ElementsAre (
+    EqualsTrade (R"(
+      state: INITIATED
+      start_time: 123
+      counterparty: "other"
+      type: BID
+      asset: "gold"
+      units: 100
+      price_sat: 42
+      role: MAKER
+    )"),
+    EqualsTrade (R"(
+      state: INITIATED
+      start_time: 123
+      counterparty: "other"
+      type: BID
+      asset: "gold"
+      units: 10
+      price_sat: 64
+      role: TAKER
+    )")
+  ));
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace democrit

--- a/src/trades_tests.cpp
+++ b/src/trades_tests.cpp
@@ -39,8 +39,6 @@ namespace
 using testing::ElementsAre;
 using testing::Return;
 
-DEFINE_PROTO_MATCHER (EqualsTradeState, TradeState)
-DEFINE_PROTO_MATCHER (EqualsTrade, Trade)
 DEFINE_PROTO_MATCHER (EqualsProcessingMessage, ProcessingMessage)
 
 constexpr auto NO_EXPIRY = std::chrono::seconds (1'000);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,6 +3,7 @@ REGTESTS = \
   orderbook.py \
   orderrefresh.py \
   trading_asset_spent.py \
+  trading_onewallet.py \
   trading_success.py
 
 SCRIPTTESTS = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,8 +4,14 @@ REGTESTS = \
   orderrefresh.py \
   trading_success.py
 
+SCRIPTTESTS = \
+  trading_conflict_chi.sh \
+  trading_conflict_name.sh
+
+dist_check_SCRIPTS = $(SCRIPTTESTS)
 noinst_PYTHON = $(REGTESTS) \
   democrit.py \
-  testcase.py
+  testcase.py \
+  trading_conflict.py
 
-TESTS = $(REGTESTS)
+TESTS = $(REGTESTS) $(SCRIPTTESTS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,8 @@
 REGTESTS = \
   getstatus.py \
   orderbook.py \
-  orderrefresh.py
+  orderrefresh.py \
+  trading_success.py
 
 noinst_PYTHON = $(REGTESTS) \
   democrit.py \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@ REGTESTS = \
   getstatus.py \
   orderbook.py \
   orderrefresh.py \
+  trading_asset_spent.py \
   trading_success.py
 
 SCRIPTTESTS = \

--- a/tests/democrit.py
+++ b/tests/democrit.py
@@ -29,6 +29,9 @@ import time
 # so we can easily test timeout behaviour.
 ORDER_TIMEOUT = 0.1
 
+# Trade timeout (also the trade refresh interval) used in tests.
+TRADE_TIMEOUT = 0.1
+
 
 class Daemon:
   """
@@ -58,6 +61,9 @@ class Daemon:
     self.args.extend (["--democrit_xid_servers", "localhost"])
     self.args.extend (["--democrit_order_timeout_ms",
                        str (int (ORDER_TIMEOUT * 1_000))])
+    self.args.extend (["--democrit_confirmations", str (10)])
+    self.args.extend (["--democrit_trade_timeout_ms",
+                       str (int (TRADE_TIMEOUT * 1_000))])
     self.args.extend (extraArgs)
 
     self.account = account
@@ -118,3 +124,18 @@ class Daemon:
       order["min_units"] = minUnits
 
     return self.rpc.addorder (order=order)
+
+  def getTrades (self):
+    """
+    Returns the list of trades as per the gettrades RPC method.  It strips
+    out the start_time fields, since those cannot be directly compared to
+    golden data.
+    """
+
+    data = self.rpc.gettrades ()
+
+    for d in data:
+      assert "start_time" in d
+      del d["start_time"]
+
+    return data

--- a/tests/democrit.py
+++ b/tests/democrit.py
@@ -1,5 +1,5 @@
 #   Democrit - atomic trades for XAYA games
-#   Copyright (C) 2020  Autonomous Worlds Ltd
+#   Copyright (C) 2020-2021  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ class Daemon:
   up afterwards.
   """
 
-  def __init__ (self, basedir, binary, port, gspRpcUrl,
+  def __init__ (self, basedir, binary, port, gspRpcUrl, xayaRpcUrl, demGspUrl,
                 account, jid, password, room, extraArgs=[]):
     """
     Constructs the manager, which will run the Democrit binary located
@@ -48,7 +48,9 @@ class Daemon:
 
     self.args = [binary]
     self.args.extend (["--rpc_port", str (port)])
-    self.args.extend (["--gsp_rpc_url", gspRpcUrl]);
+    self.args.extend (["--gsp_rpc_url", gspRpcUrl])
+    self.args.extend (["--xaya_rpc_url", xayaRpcUrl])
+    self.args.extend (["--dem_rpc_url", demGspUrl])
     self.args.extend (["--account", account])
     self.args.extend (["--jid", jid])
     self.args.extend (["--password", password])

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -188,8 +188,9 @@ class NonFungibleTest (XayaGameTest):
 
     eps = 0.1
     actual = xaya.getbalance ()
-    assert actual >= expected - eps
-    assert actual <= expected + eps
+    msg = "%f is not approx %f" % (actual, expected)
+    assert actual >= expected - eps, msg
+    assert actual <= expected + eps, msg
 
   def expectAsset (self, account, asset, expected):
     """

--- a/tests/trading_asset_spent.py
+++ b/tests/trading_asset_spent.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+#   Democrit - atomic trades for XAYA games
+#   Copyright (C) 2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests a trade where the seller double-spends the asset (sends to a
+third party) before trying to dump on a bid order.  This should fail
+the buyer's trade check and lead to the trade timing out in the end.
+"""
+
+from testcase import NonFungibleTest
+
+import json
+import time
+
+
+class TradingAssetSpentTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.rpc.xaya.createwallet ("buyer")
+    self.rpc.xaya.createwallet ("seller")
+
+    with self.runDemocrit ("buyer") as buyer, \
+         self.runDemocrit ("seller") as seller:
+
+      self.mainLogger.info ("Setting up test accounts...")
+      self.rpc.xaya.sendmany ("", {
+        seller.xaya.getnewaddress (): 100,
+        buyer.xaya.getnewaddress (): 100,
+      })
+      sellerName = "p/%s" % seller.account
+      mv = {"g": {"nf": {"m": {"a": "test", "n": 10}}}}
+      opt = {"destAddress": seller.xaya.getnewaddress ()}
+      self.rpc.xaya.name_register (sellerName, json.dumps (mv), opt)
+      demAsset = self.democritAsset (seller.account, "test")
+      jsonAsset = self.jsonAsset (seller.account, "test")
+      self.generate (1)
+      self.syncGame ()
+
+      self.mainLogger.info ("Setting up a buy order...")
+      self.assertEqual (buyer.addOrder ("bid", demAsset, 1, 10), True)
+      self.sleepSome ()
+      self.assertEqual (seller.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [
+          {
+            "account": buyer.account,
+            "id": 0,
+            "price_sat": int (1e8),
+            "min_units": 1,
+            "max_units": 10,
+          },
+        ],
+        "asks": [],
+      })
+
+      # The seller now sends the asset away to a third party (so that
+      # the selling move would be invalid) and immediately tries to also
+      # take the buy order.  This will work initially, as the orders have not
+      # been updated yet, but will fail when the buyer tries to verify
+      # the trade against the blockchain.
+      #
+      # Note:  If timing is bad, this may lead to a flaky test failure!
+
+      self.mainLogger.info ("Trying to double-spend the asset...")
+      seller.xaya.name_update (sellerName, json.dumps ({
+        "g": {"nf": {"t": {"a": jsonAsset, "n": 5, "r": "third"}}}
+      }))
+      self.generate (1)
+      self.assertEqual (seller.rpc.takeorder (units=6, order={
+        "account": buyer.account,
+        "id": 0,
+        "asset": demAsset,
+        "type": "bid",
+        "price_sat": int (1e8),
+        "max_units": 10,
+      }), True)
+
+      self.mainLogger.info ("Timing out the trade...")
+      # Note that the start time is tracked in seconds, so even though the
+      # timeout is just very short, we need to wait for a few seconds at least
+      # for it to work.
+      time.sleep (3)
+      self.updateTrades ()
+      self.assertEqual (seller.getTrades (), [{
+        "state": "abandoned",
+        "counterparty": buyer.account,
+        "asset": demAsset,
+        "type": "ask",
+        "role": "taker",
+        "price_sat": int (1e8),
+        "units": 6,
+      }])
+      self.assertEqual (buyer.getTrades (), [{
+        "state": "abandoned",
+        "counterparty": seller.account,
+        "asset": demAsset,
+        "type": "bid",
+        "role": "maker",
+        "price_sat": int (1e8),
+        "units": 6,
+      }])
+      self.assertEqual (seller.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [
+          {
+            "account": buyer.account,
+            "id": 0,
+            "price_sat": int (1e8),
+            "min_units": 1,
+            "max_units": 10,
+          },
+        ],
+        "asks": [],
+      })
+
+      self.generate (1)
+      self.expectApproxBalance (seller.xaya, 100)
+      self.expectApproxBalance (buyer.xaya, 100)
+      self.expectAsset (seller.account, jsonAsset, 5)
+      self.expectAsset ("third", jsonAsset, 5)
+      self.expectAsset (buyer.account, jsonAsset, 0)
+
+
+if __name__ == "__main__":
+  TradingAssetSpentTest ().main ()

--- a/tests/trading_conflict.py
+++ b/tests/trading_conflict.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+#   Democrit - atomic trades for XAYA games
+#   Copyright (C) 2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests a trade where the transaction gets conflicted due to an on-chain
+double spend of the name or CHI inputs.  We do this with a reorg, i.e. the
+trade will actually be confirmed temporarily but then roll back to being
+conflicted and confirm as such.
+"""
+
+from testcase import NonFungibleTest
+
+import json
+
+
+class TradingConflictTest (NonFungibleTest):
+
+  def addArguments (self, parser):
+    parser.add_argument ("--name_spent", default=False, action="store_true",
+                         help="double-spend the seller's name")
+    parser.add_argument ("--chi_spent", default=False, action="store_true",
+                         help="double-spend the buyer's CHI")
+
+  def run (self):
+    self.collectPremine ()
+
+    self.rpc.xaya.createwallet ("buyer")
+    self.rpc.xaya.createwallet ("seller")
+
+    with self.runDemocrit ("buyer") as buyer, \
+         self.runDemocrit ("seller") as seller:
+
+      self.mainLogger.info ("Setting up test accounts...")
+      self.rpc.xaya.sendmany ("", {
+        seller.xaya.getnewaddress (): 100,
+        buyer.xaya.getnewaddress (): 100,
+      })
+      sellerName = "p/%s" % seller.account
+      mv = {"g": {"nf": {"m": {"a": "test", "n": 10}}}}
+      opt = {"destAddress": seller.xaya.getnewaddress ()}
+      self.rpc.xaya.name_register (sellerName, json.dumps (mv), opt)
+      demAsset = self.democritAsset (seller.account, "test")
+      jsonAsset = self.jsonAsset (seller.account, "test")
+      self.generate (1)
+      self.syncGame ()
+
+      # We build up a long chain where the name or CHI of the buyer
+      # are double spent.  We then invalidate that long chain, do the trade,
+      # and then reconsider it to make the trade conflict.
+      self.mainLogger.info ("Generating reorg chain...")
+      self.generate (1)
+      reorgBlock = self.rpc.xaya.getbestblockhash ()
+      if self.args.name_spent:
+        seller.xaya.name_update (sellerName, "{}")
+      if self.args.chi_spent:
+        buyer.xaya.sendtoaddress (buyer.xaya.getnewaddress (), 1)
+      self.generate (20)
+      self.rpc.xaya.invalidateblock (reorgBlock)
+      self.abandonTransactions (buyer.xaya)
+      self.abandonTransactions (seller.xaya)
+      self.updateTrades ()
+
+      # Set up and take an order.
+      self.mainLogger.info ("Executing trade...")
+      self.assertEqual (seller.addOrder ("ask", demAsset, 10, 5), True)
+      self.sleepSome ()
+      self.assertEqual (buyer.rpc.takeorder (units=2, order={
+        "account": seller.account,
+        "id": 0,
+        "asset": demAsset,
+        "type": "ask",
+        "price_sat": int (10e8),
+        "max_units": 5,
+      }), True)
+      self.updateTrades ()
+      self.generate (1)
+      tradeBlock = self.rpc.xaya.getbestblockhash ()
+      self.updateTrades ()
+
+      # Check for the expected, pending trade and the outcome
+      # on-chain (which is already there after the first confirmation).
+      sellerTrade = {
+        "state": "pending",
+        "counterparty": buyer.account,
+        "asset": demAsset,
+        "type": "ask",
+        "role": "maker",
+        "price_sat": int (10e8),
+        "units": 2,
+      }
+      buyerTrade = {
+        "state": "pending",
+        "counterparty": seller.account,
+        "asset": demAsset,
+        "type": "bid",
+        "role": "taker",
+        "price_sat": int (10e8),
+        "units": 2,
+      }
+      self.assertEqual (seller.getTrades (), [sellerTrade])
+      self.assertEqual (buyer.getTrades (), [buyerTrade])
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [],
+      })
+      self.expectApproxBalance (seller.xaya, 120)
+      self.expectApproxBalance (buyer.xaya, 80)
+      self.expectAsset (seller.account, jsonAsset, 8)
+      self.expectAsset (buyer.account, jsonAsset, 2)
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [],
+      })
+
+      # Reorg to the longer chain, which will make the trade fail.
+      # We need to get 10 confirmations between first noticing the double spend
+      # and when it is actually considered failed.
+      self.mainLogger.info ("Reorging to a conflicting chain...")
+      self.rpc.xaya.reconsiderblock (reorgBlock)
+      self.updateTrades ()
+      self.expectApproxBalance (seller.xaya, 100)
+      self.expectApproxBalance (buyer.xaya, 100)
+      self.expectAsset (seller.account, jsonAsset, 10)
+      self.expectAsset (buyer.account, jsonAsset, 0)
+      self.generate (10)
+      self.updateTrades ()
+      sellerTrade["state"] = "failed"
+      buyerTrade["state"] = "failed"
+      self.assertEqual (seller.getTrades (), [sellerTrade])
+      self.assertEqual (buyer.getTrades (), [buyerTrade])
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [
+          {
+            "account": seller.account,
+            "id": 0,
+            "price_sat": int (10e8),
+            "min_units": 1,
+            "max_units": 5,
+          },
+        ],
+      })
+
+  def abandonTransactions (self, rpc):
+    """
+    Runs listtransactions on the given Xaya Core RPC, and explicitly
+    abandons all transactions that are unconfirmed.
+    """
+
+    for tx in rpc.listtransactions ():
+      if tx["confirmations"] > 0:
+        continue
+
+      try:
+        rpc.abandontransaction (tx["txid"])
+      except:
+        pass
+
+
+if __name__ == "__main__":
+  TradingConflictTest ().main ()

--- a/tests/trading_conflict_chi.sh
+++ b/tests/trading_conflict_chi.sh
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+${srcdir}/trading_conflict.py --chi_spent

--- a/tests/trading_conflict_name.sh
+++ b/tests/trading_conflict_name.sh
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+${srcdir}/trading_conflict.py --name_spent

--- a/tests/trading_onewallet.py
+++ b/tests/trading_onewallet.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+#   Democrit - atomic trades for XAYA games
+#   Copyright (C) 2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests trading between two daemons with the same underlying wallet.
+This will trip the signature checks built into the verification
+logic (i.e. that the counterparty can not trick us into signing
+more inputs than expected).
+
+Note that since the buyer signs first in all cases (even though a maker/buyer
+does not share the signatures initially), the buyer's check will be
+triggered in this test.  For the seller's check, we rely just on the
+unit tests present, as that would be harder to cross-check in an
+integration test.
+"""
+
+from testcase import NonFungibleTest
+
+import json
+import time
+
+
+class TradingOneWalletTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.rpc.xaya.createwallet ("wallet")
+
+    with self.runDemocrit ("wallet") as buyer, \
+         self.runDemocrit ("wallet") as seller:
+
+      self.mainLogger.info ("Setting up test accounts...")
+      self.rpc.xaya.sendtoaddress (buyer.xaya.getnewaddress (), 100)
+      sellerName = "p/%s" % seller.account
+      mv = {"g": {"nf": {"m": {"a": "test", "n": 10}}}}
+      opt = {"destAddress": seller.xaya.getnewaddress ()}
+      self.rpc.xaya.name_register (sellerName, json.dumps (mv), opt)
+      demAsset = self.democritAsset (seller.account, "test")
+      jsonAsset = self.jsonAsset (seller.account, "test")
+      self.generate (1)
+      self.syncGame ()
+
+      self.mainLogger.info ("Setting up orders...")
+      self.assertEqual (seller.addOrder ("ask", demAsset, 10, 5), True)
+      self.assertEqual (buyer.addOrder ("bid", demAsset, 5, 2), True)
+      self.sleepSome ()
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [
+          {
+            "account": seller.account,
+            "id": 0,
+            "price_sat": int (10e8),
+            "min_units": 1,
+            "max_units": 5,
+          },
+        ],
+      })
+      self.assertEqual (seller.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [
+          {
+            "account": buyer.account,
+            "id": 0,
+            "price_sat": int (5e8),
+            "min_units": 1,
+            "max_units": 2,
+          },
+        ],
+        "asks": [],
+      })
+
+      self.mainLogger.info ("Taking orders...")
+      self.assertEqual (seller.rpc.takeorder (units=2, order={
+        "account": buyer.account,
+        "id": 0,
+        "asset": demAsset,
+        "type": "bid",
+        "price_sat": int (5e8),
+        "max_units": 2,
+      }), True)
+      self.updateTrades ()
+      self.assertEqual (buyer.rpc.takeorder (units=3, order={
+            "account": seller.account,
+            "id": 0,
+            "asset": demAsset,
+            "type": "ask",
+            "price_sat": int (10e8),
+            "max_units": 5,
+      }), True)
+      self.updateTrades ()
+
+      self.mainLogger.info ("Timing out failed trades...")
+      time.sleep (3)
+      # We do not care about the details of the trades (there are enough
+      # other tests for that), but we should have two abandoned trades
+      # in each account.
+      for d in [buyer, seller]:
+        trades = d.getTrades ()
+        self.assertEqual ([t["state"] for t in trades], ["abandoned"] * 2)
+
+      # Since no transactions have been made at all, the balance
+      # should actually be exact this time.
+      for d in [buyer, seller]:
+        self.assertEqual (d.xaya.getbalance (), 100)
+      self.expectAsset (seller.account, jsonAsset, 10)
+      self.expectAsset (buyer.account, jsonAsset, 0)
+
+
+if __name__ == "__main__":
+  TradingOneWalletTest ().main ()

--- a/tests/trading_success.py
+++ b/tests/trading_success.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+#   Democrit - atomic trades for XAYA games
+#   Copyright (C) 2021  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests a "normal", successful trade flow between two parties.
+"""
+
+from testcase import NonFungibleTest
+
+import json
+
+
+class TradingSuccessTest (NonFungibleTest):
+
+  def run (self):
+    self.collectPremine ()
+
+    self.rpc.xaya.createwallet ("buyer")
+    self.rpc.xaya.createwallet ("seller")
+
+    with self.runDemocrit ("buyer") as buyer, \
+         self.runDemocrit ("seller") as seller:
+
+      self.mainLogger.info ("Setting up test accounts...")
+      self.rpc.xaya.sendmany ("", {
+        seller.xaya.getnewaddress (): 100,
+        buyer.xaya.getnewaddress (): 100,
+      })
+      sellerName = "p/%s" % seller.account
+      mv = {"g": {"nf": {"m": {"a": "test", "n": 10}}}}
+      opt = {"destAddress": seller.xaya.getnewaddress ()}
+      self.rpc.xaya.name_register (sellerName, json.dumps (mv), opt)
+      demAsset = self.democritAsset (seller.account, "test")
+      jsonAsset = self.jsonAsset (seller.account, "test")
+      self.generate (1)
+      self.syncGame ()
+
+      self.mainLogger.info ("Setting up orders...")
+      self.assertEqual (seller.addOrder ("ask", demAsset, 10, 5), True)
+      self.assertEqual (buyer.addOrder ("bid", demAsset, 5, 2), True)
+      self.sleepSome ()
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [
+          {
+            "account": seller.account,
+            "id": 0,
+            "price_sat": int (10e8),
+            "min_units": 1,
+            "max_units": 5,
+          },
+        ],
+      })
+      self.assertEqual (seller.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [
+          {
+            "account": buyer.account,
+            "id": 0,
+            "price_sat": int (5e8),
+            "min_units": 1,
+            "max_units": 2,
+          },
+        ],
+        "asks": [],
+      })
+
+      self.mainLogger.info ("Taking buy order...")
+      self.assertEqual (seller.rpc.takeorder (units=2, order={
+        "account": buyer.account,
+        "id": 0,
+        "asset": demAsset,
+        "type": "bid",
+        "price_sat": int (5e8),
+        "max_units": 2,
+      }), True)
+      self.updateTrades ()
+      sellerTrade1 = {
+        "state": "pending",
+        "counterparty": buyer.account,
+        "asset": demAsset,
+        "type": "ask",
+        "role": "taker",
+        "price_sat": int (5e8),
+        "units": 2,
+      }
+      buyerTrade1 = {
+        "state": "pending",
+        "counterparty": seller.account,
+        "asset": demAsset,
+        "type": "bid",
+        "role": "maker",
+        "price_sat": int (5e8),
+        "units": 2,
+      }
+      self.assertEqual (seller.getTrades (), [sellerTrade1])
+      self.assertEqual (buyer.getTrades (), [buyerTrade1])
+      self.assertEqual (seller.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [],
+      })
+
+      # Updating the name and spending more CHI now should work, but it
+      # will be based on the unconfirmed output in the wallet and thus
+      # not invalidate the trade.  Spending the CHI only works after
+      # one confirmation due to wallet handling.
+      seller.xaya.name_update (sellerName, "{}")
+      self.generate (1)
+      buyer.xaya.sendtoaddress (seller.xaya.getnewaddress (), 1)
+
+      # Finish the trade.  It will be seen as successful after 10 confirmations.
+      self.generate (8)
+      self.updateTrades ()
+      self.assertEqual (seller.getTrades (), [sellerTrade1])
+      self.assertEqual (buyer.getTrades (), [buyerTrade1])
+      self.generate (1)
+      self.updateTrades ()
+      sellerTrade1["state"] = "success"
+      buyerTrade1["state"] = "success"
+      self.assertEqual (seller.getTrades (), [sellerTrade1])
+      self.assertEqual (buyer.getTrades (), [buyerTrade1])
+
+      # Check the outcome, i.e. that the asset and CHI have been transferred
+      # as expected.
+      self.expectApproxBalance (seller.xaya, 111)
+      self.expectApproxBalance (buyer.xaya, 89)
+      self.expectAsset (seller.account, jsonAsset, 8)
+      self.expectAsset (buyer.account, jsonAsset, 2)
+
+      self.mainLogger.info ("Taking sell order...")
+      self.assertEqual (buyer.rpc.takeorder (units=3, order={
+            "account": seller.account,
+            "id": 0,
+            "asset": demAsset,
+            "type": "ask",
+            "price_sat": int (10e8),
+            "max_units": 5,
+      }), True)
+      self.updateTrades ()
+      sellerTrade2 = {
+        "state": "pending",
+        "counterparty": buyer.account,
+        "asset": demAsset,
+        "type": "ask",
+        "role": "maker",
+        "price_sat": int (10e8),
+        "units": 3,
+      }
+      buyerTrade2 = {
+        "state": "pending",
+        "counterparty": seller.account,
+        "asset": demAsset,
+        "type": "bid",
+        "role": "taker",
+        "price_sat": int (10e8),
+        "units": 3,
+      }
+      self.assertEqual (seller.getTrades (), [sellerTrade2, sellerTrade1])
+      self.assertEqual (buyer.getTrades (), [buyerTrade2, buyerTrade1])
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [],
+      })
+
+      self.generate (10)
+      self.updateTrades ()
+      sellerTrade2["state"] = "success"
+      buyerTrade2["state"] = "success"
+      self.assertEqual (seller.getTrades (), [sellerTrade1, sellerTrade2])
+      self.assertEqual (buyer.getTrades (), [buyerTrade1, buyerTrade2])
+      self.assertEqual (buyer.rpc.getordersforasset (asset=demAsset), {
+        "asset": demAsset,
+        "bids": [],
+        "asks": [
+          {
+            "account": seller.account,
+            "id": 1,
+            "price_sat": int (10e8),
+            "min_units": 1,
+            "max_units": 2,
+          },
+        ],
+      })
+
+      self.expectApproxBalance (seller.xaya, 111 + 30)
+      self.expectApproxBalance (buyer.xaya, 89 - 30)
+      self.expectAsset (seller.account, jsonAsset, 8 - 3)
+      self.expectAsset (buyer.account, jsonAsset, 2 + 3)
+
+
+if __name__ == "__main__":
+  TradingSuccessTest ().main ()


### PR DESCRIPTION
This implements the logic for actually executing a trade between two parties.  They will exchange XMPP messages in private to finalise the atomic transaction, and then the maker will broadcast it.  Both parties then monitor the network and blockchain and will determine when a trade has succeeded (or failed due to a double spend).

From the user's point of view, all this is almost completely transparent.  There is just a new method to take an order, and one to return the list and states of active trades.  All else is done automatically.